### PR TITLE
Upgrade urllib3 to 1.25.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ pytest-cov==2.6.0
 pytz==2018.6
 requests==2.20.0
 six==1.11.0
-urllib3==1.24
+urllib3==1.25.2

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
         "lxml==4.2.5",
         "pytz==2018.6",
         "requests==2.20.0",
-        "urllib3==1.24",
+        "urllib3==1.25.2",
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
`urllib3 < 1.24.2` has [a security vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2019-11324).

This change upgrades to the latest version of `urllib3`.