### PR TITLE
Downgrade urllib3 to 1.24.3 to fulfill requests@2.20.0 requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ pytest-cov==2.6.0
 pytz==2018.6
 requests==2.20.0
 six==1.11.0
-urllib3==1.25.2
+urllib3==1.24.3

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="basketball_reference_web_scraper",
-    version="4.2.2",
+    version="4.2.3",
     author="Jae Bradley",
     author_email="jae.b.bradley@gmail.com",
     license="MIT",
@@ -22,7 +22,7 @@ setuptools.setup(
         "lxml==4.2.5",
         "pytz==2018.6",
         "requests==2.20.0",
-        "urllib3==1.25.2",
+        "urllib3==1.24.3",
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Related to #81 and #82.

I had bumped `urllib3` to the latest version at the time (`1.25.2`) in #80 to resolve a security vulnerability in `urllib3 < 1.24.2`.

However, this meant that the required `requests` version, `2.20.0` had the wrong `urllib3` version.

`urllib3@1.24.3` both avoids the security vulnerability and fulfills `requests`' `urllib3` version requirements.