### PR TITLE
v4.4.1

### DIFF
--- a/basketball_reference_web_scraper/parsers/box_scores/teams.py
+++ b/basketball_reference_web_scraper/parsers/box_scores/teams.py
@@ -35,7 +35,7 @@ def parse_team_totals(page):
     footers = [
         footer
         for table in tables
-        if "basic" in table.attrib["id"]
+        if "game-basic" in table.attrib["id"]
         for footer in table.xpath("tfoot")
     ]
     return [

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="basketball_reference_web_scraper",
-    version="4.4.0",
+    version="4.4.1",
     author="Jae Bradley",
     author_email="jae.b.bradley@gmail.com",
     license="MIT",

--- a/tests/201701010ATL.html
+++ b/tests/201701010ATL.html
@@ -6,48 +6,53 @@
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=2.0" />
-    <link rel="dns-prefetch" href="https://d2p3bygnnzw9w3.cloudfront.net/req/201811271" />
+    <link rel="dns-prefetch" href="https://d2p3bygnnzw9w3.cloudfront.net/req/201909231" />
 
 <!-- yes:cookie regular load the cached css -->
+
+<script>function gup(n) {n = n.replace(/[\[]/, '\\[').replace(/[\]]/, '\\]'); var r = new RegExp('[\\?&]'+n+'=([^&#]*)'); var re = r.exec(location.search);   return re === null?'':decodeURIComponent(re[1].replace(/\+/g,' '));}; document.srdev = gup('srdev')</script>
 <link rel="preconnect" href="https://d2p3bygnnzw9w3.cloudfront.net" crossorigin>
 <link rel="preconnect" href="https://d2cwpp38twqe55.cloudfront.net" crossorigin>
-<link rel="stylesheet" href="https://d2p3bygnnzw9w3.cloudfront.net/req/201812041/css/bbr/sr-min.css" type="text/css" />
-<link rel="preload"    href="https://d2p3bygnnzw9w3.cloudfront.net/req/201812041/js/bbr/sr-min.js" as="script" crossorigin>
-<link rel="preload"    href="https://d2p3bygnnzw9w3.cloudfront.net/req/201812041/icons/sr_icons-min.svg?bbr" as="fetch" crossorigin>
+<link rel="stylesheet" href="https://d2p3bygnnzw9w3.cloudfront.net/req/201909273/css/bbr/sr-min.css" type="text/css"
+      onload="if (document.srdev) { this.href = 'https://d2p3bygnnzw9w3.cloudfront.net/nocdn/dev/'.concat(document.srdev.substr(0,2),'/css/bbr/sr.css'); }" />
+<link rel="preload"    href="https://d2p3bygnnzw9w3.cloudfront.net/req/201909273/js/bbr/sr-min.js" as="script" crossorigin>
+
+
+<script class="allowed">var sr_is_production = true;
+function vjs_getUrlParameter(e){e=e.replace(/[\[]/,"\\[").replace(/[\]]/,"\\]");var t=new RegExp("[\\?&]"+e+"=([^&#]*)").exec(location.search);return null===t?"":decodeURIComponent(t[1].replace(/\+/g," "))}document.lang="","/es/"===window.location.pathname.substr(0,4)?document.lang="es":"/pt/"===window.location.pathname.substr(0,4)?document.lang="pt":"/fr/"===window.location.pathname.substr(0,4)?document.lang="fr":"/it/"===window.location.pathname.substr(0,4)?document.lang="it":"/de/"===window.location.pathname.substr(0,4)?document.lang="de":(window.location.pathname.substr(0,4),document.lang="en"),vjs_getUrlParameter("lang")&&(document.lang=vjs_getUrlParameter("lang")),document.srdev=null,vjs_getUrlParameter("srdev")&&(document.srdev=vjs_getUrlParameter("srdev"));var log_performance=!0,is_new_jscss_version=!1,sr_detect_operaMini=-1<navigator.userAgent.indexOf("Opera Mini");sr_detect_operaMini&&((el=document.querySelector("html")).className=el.className.concat(" operamini"));var sr_detect_firefox=-1<navigator.userAgent.indexOf("Firefox");sr_detect_firefox&&((el=document.querySelector("html")).className=el.className.concat(" firefox"));var sr_detect_firefoxMobile=-1<navigator.userAgent.indexOf("Firefox")&&(-1<navigator.userAgent.indexOf("Mobile")||-1<navigator.userAgent.indexOf("Tablet"));sr_detect_firefoxMobile&&((el=document.querySelector("html")).className=el.className.concat(" firefox-mobile"));var el,sr_detect_ie=function(){var e=window.navigator.userAgent;if(0<e.indexOf("Trident/7.0"))return 11;if(0<e.indexOf("Trident/6.0"))return 10;if(0<e.indexOf("Trident/5.0"))return 9;for(var t=3,n=document.createElement("div"),r=n.getElementsByTagName("i");n.innerHTML="\x3c!--[if gt IE "+ ++t+"]><i></i><![endif]--\x3e",r[0];);return 4<t&&t}(),sr_detect_edge=!sr_detect_ie&&!!window.StyleMedia,sr_detect_safari=/Safari/.test(navigator.userAgent)&&/Apple Computer/.test(navigator.vendor),className="no-js";(el=document.querySelector("html")).classList?el.classList.remove(className):el.className=el.className.replace(new RegExp("(^|\\b)"+className.split(" ").join("|")+"(\\b|)","gi")," "),el.className=el.className.concat(" js"),function(a,m,f){function p(e,t){return typeof e===t}function h(){return"function"!=typeof m.createElement?m.createElement(arguments[0]):y?m.createElementNS.call(m,"http://www.w3.org/2000/svg",arguments[0]):m.createElement.apply(m,arguments)}function o(e,t,n,r){var o,i,a,s,l,c="modernizr",d=h("div"),u=((l=m.body)||((l=h(y?"svg":"body")).fake=!0),l);if(parseInt(n,10))for(;n--;)(a=h("div")).id=r?r[n]:c+(n+1),d.appendChild(a);return(o=h("style")).type="text/css",o.id="s"+c,(u.fake?u:d).appendChild(o),u.appendChild(d),o.styleSheet?o.styleSheet.cssText=e:o.appendChild(m.createTextNode(e)),d.id=c,u.fake&&(u.style.background="",u.style.overflow="hidden",s=_.style.overflow,_.style.overflow="hidden",_.appendChild(u)),i=t(d,e),u.fake?(u.parentNode.removeChild(u),_.style.overflow=s,_.offsetHeight):d.parentNode.removeChild(d),!!i}function v(e){return e.replace(/([a-z])-([a-z])/g,function(e,t,n){return t+n.toUpperCase()}).replace(/^-/,"")}function s(e,t){return function(){return e.apply(t,arguments)}}function i(e){return e.replace(/([A-Z])/g,function(e,t){return"-"+t.toLowerCase()}).replace(/^ms-/,"-ms-")}function g(e,t){var n=e.length;if("CSS"in a&&"supports"in a.CSS){for(;n--;)if(a.CSS.supports(i(e[n]),t))return!0;return!1}if("CSSSupportsRule"in a){for(var r=[];n--;)r.push("("+i(e[n])+":"+t+")");return o("@supports ("+(r=r.join(" or "))+") { #modernizr { position: absolute; } }",function(e){return"absolute"==function(e,t,n){var r;if("getComputedStyle"in a){r=getComputedStyle.call(a,e,t);var o=a.console;null!==r?n&&(r=r.getPropertyValue(n)):o&&o[o.error?"error":"log"].call(o,"getComputedStyle returning null, its possible modernizr test results are inaccurate")}else r=!t&&e.currentStyle&&e.currentStyle[n];return r}(e,null,"position")})}return f}function r(e,t,n,r,o){var i=e.charAt(0).toUpperCase()+e.slice(1),a=(e+" "+z.join(i+" ")+i).split(" ");return p(t,"string")||p(t,"undefined")?function(e,t,n,r){function o(){a&&(delete T.style,delete T.modElem)}if(r=!p(r,"undefined")&&r,!p(n,"undefined")){var i=g(e,n);if(!p(i,"undefined"))return i}for(var a,s,l,c,d,u=["modernizr","tspan","samp"];!T.style&&u.length;)a=!0,T.modElem=h(u.shift()),T.style=T.modElem.style;for(l=e.length,s=0;s<l;s++)if(c=e[s],d=T.style[c],!!~(""+c).indexOf("-")&&(c=v(c)),T.style[c]!==f){if(r||p(n,"undefined"))return o(),"pfx"!=t||c;try{T.style[c]=n}catch(e){}if(T.style[c]!=d)return o(),"pfx"!=t||c}return o(),!1}(a,t,r,o):function(e,t,n){var r;for(var o in e)if(e[o]in t)return!1===n?e[o]:p(r=t[e[o]],"function")?s(r,n||t):r;return!1}(a=(e+" "+x.join(i+" ")+i).split(" "),t,n)}function e(e,t,n){return r(e,f,f,t,n)}var l=[],c=[],t={_version:"3.6.0",_config:{classPrefix:"",enableClasses:!0,enableJSClass:!0,usePrefixes:!0},_q:[],on:function(e,t){var n=this;setTimeout(function(){t(n[e])},0)},addTest:function(e,t,n){c.push({name:e,fn:t,options:n})},addAsyncTest:function(e){c.push({name:null,fn:e})}},d=function(){};d.prototype=t,(d=new d).addTest("cookies",function(){try{m.cookie="cookietest=1";var e=-1!=m.cookie.indexOf("cookietest=");return m.cookie="cookietest=1; expires=Thu, 01-Jan-1970 00:00:01 GMT",e}catch(e){return!1}}),d.addTest("cors","XMLHttpRequest"in a&&"withCredentials"in new XMLHttpRequest),d.addTest("history",function(){var e=navigator.userAgent;return(-1===e.indexOf("Android 2.")&&-1===e.indexOf("Android 4.0")||-1===e.indexOf("Mobile Safari")||-1!==e.indexOf("Chrome")||-1!==e.indexOf("Windows Phone")||"file:"===location.protocol)&&(a.history&&"pushState"in a.history)}),d.addTest("localstorage",function(){var e="modernizr";try{return localStorage.setItem(e,e),localStorage.removeItem(e),!0}catch(e){return!1}}),d.addTest("sessionstorage",function(){var e="modernizr";try{return sessionStorage.setItem(e,e),sessionStorage.removeItem(e),!0}catch(e){return!1}});var u=t._config.usePrefixes?" -webkit- -moz- -o- -ms- ".split(" "):["",""];t._prefixes=u;var _=m.documentElement,y="svg"===_.nodeName.toLowerCase();y||function(e,a){function u(e,t){var n=e.createElement("p"),r=e.getElementsByTagName("head")[0]||e.documentElement;return n.innerHTML="x<style>"+t+"</style>",r.insertBefore(n.lastChild,r.firstChild)}function m(){var e=g.elements;return"string"==typeof e?e.split(" "):e}function f(e){var t=v[e[d]];return t||(t={},h++,e[d]=h,v[h]=t),t}function o(e,t,n){return t||(t=a),s?t.createElement(e):(n||(n=f(t)),!(r=n.cache[e]?n.cache[e].cloneNode():c.test(e)?(n.cache[e]=n.createElem(e)).cloneNode():n.createElem(e)).canHaveChildren||l.test(e)||r.tagUrn?r:n.frag.appendChild(r));var r}function r(e){e||(e=a);var t,n,r=f(e);return!g.shivCSS||i||r.hasCSS||(r.hasCSS=!!u(e,"article,aside,dialog,figcaption,figure,footer,header,hgroup,main,nav,section{display:block}mark{background:#FF0;color:#000}template{display:none}")),s||(t=e,(n=r).cache||(n.cache={},n.createElem=t.createElement,n.createFrag=t.createDocumentFragment,n.frag=n.createFrag()),t.createElement=function(e){return g.shivMethods?o(e,t,n):n.createElem(e)},t.createDocumentFragment=Function("h,f","return function(){var n=f.cloneNode(),c=n.createElement;h.shivMethods&&("+m().join().replace(/[\w\-:]+/g,function(e){return n.createElem(e),n.frag.createElement(e),'c("'+e+'")'})+");return n}")(g,n.frag)),e}function p(e){for(var t,n=e.attributes,r=n.length,o=e.ownerDocument.createElement(w+":"+e.nodeName);r--;)(t=n[r]).specified&&o.setAttribute(t.nodeName,t.nodeValue);return o.style.cssText=e.style.cssText,o}function t(s){function l(){clearTimeout(e._removeSheetTimer),c&&c.removeNode(!0),c=null}var c,d,e=f(s),t=s.namespaces,n=s.parentWindow;return!M||s.printShived||(void 0===t[w]&&t.add(w),n.attachEvent("onbeforeprint",function(){l();for(var e,t,n,r=s.styleSheets,o=[],i=r.length,a=Array(i);i--;)a[i]=r[i];for(;n=a.pop();)if(!n.disabled&&y.test(n.media)){try{t=(e=n.imports).length}catch(e){t=0}for(i=0;i<t;i++)a.push(e[i]);try{o.push(n.cssText)}catch(e){}}o=function(e){for(var t,n=e.split("{"),r=n.length,o=RegExp("(^|[\\s,>+~])("+m().join("|")+")(?=[[\\s,>+~#.:]|)","gi"),i="1"+w+"\\:2";r--;)(t=n[r]=n[r].split("}"))[t.length-1]=t[t.length-1].replace(o,i),n[r]=t.join("}");return n.join("{")}(o.reverse().join("")),d=function(e){for(var t,n=e.getElementsByTagName("*"),r=n.length,o=RegExp("^(?:"+m().join("|")+")","i"),i=[];r--;)t=n[r],o.test(t.nodeName)&&i.push(t.applyElement(p(t)));return i}(s),c=u(s,o)}),n.attachEvent("onafterprint",function(){(function(e){for(var t=e.length;t--;)e[t].removeNode()})(d),clearTimeout(e._removeSheetTimer),e._removeSheetTimer=setTimeout(l,500)}),s.printShived=!0),s}var i,s,n=e.html5||{},l=/^<|^(?:button|map|select|textarea|object|iframe|option|optgroup)/i,c=/^(?:a|b|code|div|fieldset|h1|h2|h3|h4|h5|h6|i|label|li|ol|p|q|span|strong|style|table|tbody|td|th|tr|ul)/i,d="_html5shiv",h=0,v={};!function(){try{var e=a.createElement("a");e.innerHTML="<xyz></xyz>",i="hidden"in e,s=1==e.childNodes.length||function(){a.createElement("a");var e=a.createDocumentFragment();return void 0===e.cloneNode||void 0===e.createDocumentFragment||void 0===e.createElement}()}catch(e){s=i=!0}}();var g={elements:n.elements||"abbr article aside audio bdi canvas data datalist details dialog figcaption figure footer header hgroup main mark meter nav output picture progress section summary template time video",version:"3.7.3",shivCSS:!1!==n.shivCSS,supportsUnknownElements:s,shivMethods:!1!==n.shivMethods,type:"default",shivDocument:r,createElement:o,createDocumentFragment:function(e,t){if(e||(e=a),s)return e.createDocumentFragment();for(var n=(t=t||f(e)).frag.cloneNode(),r=0,o=m(),i=o.length;r<i;r++)n.createElement(o[r]);return n},addElements:function(e,t){var n=g.elements;"string"!=typeof n&&(n=n.join(" ")),"string"!=typeof e&&(e=e.join(" ")),g.elements=n+" "+e,r(t)}};e.html5=g,r(a);var _,y=/^|\b(?:all|print)\b/,w="html5shiv",M=!(s||(_=a.documentElement,void 0===a.namespaces||void 0===a.parentWindow||void 0===_.applyElement||void 0===_.removeNode||void 0===e.attachEvent));g.type+=" print",(g.shivPrint=t)(a),"object"==typeof module&&module.exports&&(module.exports=g)}(void 0!==a?a:this,m),d.addTest("canvas",function(){var e=h("canvas");return!(!e.getContext||!e.getContext("2d"))});var w,n=(w=!("onblur"in m.documentElement),function(e,t){var n;return!!e&&(t&&"string"!=typeof t||(t=h(t||"div")),!(n=(e="on"+e)in t)&&w&&(t.setAttribute||(t=h("div")),t.setAttribute(e,""),n="function"==typeof t[e],t[e]!==f&&(t[e]=f),t.removeAttribute(e)),n)});t.hasEvent=n;var M=t.testStyles=o;d.addTest("touchevents",function(){var t;if("ontouchstart"in a||a.DocumentTouch&&m instanceof DocumentTouch)t=!0;else{var e=["@media (",u.join("touch-enabled),("),"heartz",")","{#modernizr{top:9px;position:absolute}}"].join("");M(e,function(e){t=9===e.offsetTop})}return t}),d.addTest("unicode",function(){var t,n=h("span"),r=h("span");return M("#modernizr{font-family:Arial,sans;font-size:300em;}",function(e){n.innerHTML=y?"妇":"&#5987;",r.innerHTML=y?"☆":"&#9734;",e.appendChild(n),e.appendChild(r),t="offsetWidth"in n&&n.offsetWidth!==r.offsetWidth}),t});var b="Moz O ms Webkit",x=t._config.usePrefixes?b.toLowerCase().split(" "):[];t._domPrefixes=x,d.addTest("pointerevents",function(){var e=!1,t=x.length;for(e=d.hasEvent("pointerdown");t--&&!e;)n(x[t]+"pointerdown")&&(e=!0);return e});var z=t._config.usePrefixes?b.split(" "):[];t._cssomPrefixes=z;var E=function(e){var t,n=u.length,r=a.CSSRule;if(void 0===r)return f;if(!e)return!1;if((t=(e=e.replace(/^@/,"")).replace(/-/g,"_").toUpperCase()+"_RULE")in r)return"@"+e;for(var o=0;o<n;o++){var i=u[o];if(i.toUpperCase()+"_"+t in r)return"@-"+i.toLowerCase()+"-"+e}return!1};t.atRule=E;var S={elem:h("modernizr")};d._q.push(function(){delete S.elem});var T={style:S.elem.style};d._q.unshift(function(){delete T.style}),t.testAllProps=r;var C=t.prefixed=function(e,t,n){return 0===e.indexOf("@")?E(e):(-1!=e.indexOf("-")&&(e=v(e)),t?r(e,t,n):r(e,"pfx"))};d.addTest("vibrate",!!C("vibrate",navigator)),d.addTest("matchmedia",!!C("matchMedia",a)),t.testAllProps=e,d.addTest("flexwrap",e("flexWrap","wrap",!0)),function(){var e,t,n,r,o,i;for(var a in c)if(c.hasOwnProperty(a)){if(e=[],(t=c[a]).name&&(e.push(t.name.toLowerCase()),t.options&&t.options.aliases&&t.options.aliases.length))for(n=0;n<t.options.aliases.length;n++)e.push(t.options.aliases[n].toLowerCase());for(r=p(t.fn,"function")?t.fn():t.fn,o=0;o<e.length;o++)1===(i=e[o].split(".")).length?d[i[0]]=r:(!d[i[0]]||d[i[0]]instanceof Boolean||(d[i[0]]=new Boolean(d[i[0]])),d[i[0]][i[1]]=r),l.push((r?"":"no-")+i.join("-"))}}(),function(e){var t=_.className,n=d._config.classPrefix||"";if(y&&(t=t.baseVal),d._config.enableJSClass){var r=new RegExp("(^|\\s)"+n+"no-js(\\s|)");t=t.replace(r,"1"+n+"js2")}d._config.enableClasses&&(t+=" "+n+e.join(" "+n),y?_.className.baseVal=t:_.className=t)}(l),delete t.addTest,delete t.addAsyncTest;for(var N=0;N<d._q.length;N++)d._q[N]();a.Modernizr=d}(window,document),Modernizr.viewport_width=Math.max(document.documentElement.clientWidth,window.innerWidth||0),Modernizr.viewport_height=Math.max(document.documentElement.clientHeight,window.innerHeight||0),Modernizr.narrow=Modernizr.viewport_width<=704,Modernizr.constrained=Modernizr.viewport_width<=1200,Modernizr.site_menu=Modernizr.viewport_width<=1020?"button":"nav_bar",Modernizr.touch=Modernizr.touchevents||Modernizr.pointerevents&&(0<navigator.MaxTouchPoints||0<navigator.msMaxTouchPoints),Modernizr.phone=Modernizr.narrow&&Modernizr.touch,Modernizr.tablet=Modernizr.viewport_width<1075&&Modernizr.touch,Modernizr.desktop=!Modernizr.constrained&&!Modernizr.touch,Modernizr.laptop=!(Modernizr.desktop||Modernizr.tablet||Modernizr.phone);var patt=new RegExp("hideallads");Modernizr.adfree=patt.test(window.location.href);var sr_html=document.querySelector("html"),cn=sr_html.className;Modernizr.phone?sr_html.className=cn.concat(" phone"):Modernizr.tablet?sr_html.className=cn.concat(" tablet"):(Modernizr.desktop||Modernizr.laptop)&&(sr_html.className=cn.concat(" desktop"));var sr_host_parts=window.location.hostname.split(".");cn=sr_html.className;Modernizr.is_build=Modernizr.is_live=Modernizr.is_dev=!1,"b"===sr_host_parts[0]?(Modernizr.is_build=!0,sr_html.className=cn.concat(" is_build")):"d"===sr_host_parts[0]||"r"===sr_host_parts[0]?(Modernizr.is_dev=!0,sr_html.className=cn.concat(" is_dev")):"www"!==sr_host_parts[0]&&"fbref"!==sr_host_parts[0]||(Modernizr.is_live=!0,sr_html.className=cn.concat(" is_live"));var sr_logger=function(){var e=null,t={enableLogger:function(){null!=e&&(window.console.log=e)},disableLogger:function(){e=console.log,window.console.log=function(){}}};return t}();!document.srdev&&sr_is_production&&sr_logger.disableLogger(),Modernizr.is_modern=(Modernizr.canvas||Modernizr.localstorage)&&!sr_detect_operaMini,Modernizr.is_modern?(document.documentElement.className+=" is_modern",Modernizr.is_not_modern=!1):(document.documentElement.className+=" is_not_modern",Modernizr.is_not_modern=!0),Modernizr.lang=document.lang||"",Modernizr.srdev=document.srdev;var sr_utilities_js_loader=[];function vjs_readCookie(e){for(var t=e+"=",n=document.cookie.split(";"),r=0;r<n.length;r++){for(var o=n[r];" "===o.charAt(0);)o=o.substring(1,o.length);if(0===o.indexOf(t))return decodeURIComponent(o.substring(t.length,o.length))}return null}function vjs_createCookie(e,t,n){var r="";if(n){var o=new Date;o.setTime(o.getTime()+24*n*60*60*1e3),r="; expires="+o.toGMTString()}else r="";var i=encodeURIComponent(e)+"="+encodeURIComponent(t)+r+"; path=/";document.cookie=i}!function(o){var e=function(e,t){"use strict";var n=o.document.getElementsByTagName("script")[0],r=o.document.createElement("script");return r.src=e,r.async=!0,n.parentNode.insertBefore(r,n),t&&"function"==typeof t&&(r.onload=t),r};"undefined"!=typeof module?module.exports=e:o.loadJS=e}("undefined"!=typeof global?global:this),String.prototype.vjs_isMatch=function(e){return null!==this.match(e)};var sr_time_begin=new Date,sr_perf_startTime=new Date,sr_perf_log="<strong>Performance:</strong>",sr_perf_lastTime=new Date;function vjs_ready(e){"loading"!=document.readyState?e():document.addEventListener("DOMContentLoaded",e)}
+
+</script>
+
+<script>
+var _sr_modern_url = ''.concat(document.srdev?'https://d2p3bygnnzw9w3.cloudfront.net/nocdn/dev/'.concat(document.srdev.substring(0, 2)):"https://d2p3bygnnzw9w3.cloudfront.net/req/201909273",
+                               "/js/bbr", "/sr",document.srdev?"":"-min",   			       ".js");
+var _sr_basic_url = "https://d2p3bygnnzw9w3.cloudfront.net/req/201909273/js/bbr/sr-basic".concat("-min", ".js");
+if (Modernizr.is_modern) { loadJS( _sr_modern_url, function() { vjs_ready(sr_fire_js); }); }
+else                     { loadJS( _sr_basic_url, function() { vjs_ready(sr_fire_js); }); }
+</script>
+<link rel="preload"    href="https://d2p3bygnnzw9w3.cloudfront.net/req/201909273/icons/sr_icons-min.svg?bbr" as="fetch" crossorigin>
 <link rel="preload"    href="https://d2cwpp38twqe55.cloudfront.net/short/inc/main_nav_menu.json" as="fetch" crossorigin>
 <link rel="preload"    href="https://d2p3bygnnzw9w3.cloudfront.net/req/201604190/images/chosen-sprite.png" as="image" crossorigin>
 <link rel="preconnect" href="https://www.google-analytics.com"  crossorigin>
 <link rel="preconnect" href="https://www.googletagservices.com" crossorigin>
 
 
-<script class="allowed">var sr_is_production = true;
-function vjs_ready(e){"loading"!=document.readyState?e():document.addEventListener("DOMContentLoaded",e)}var log_performance=!1,is_new_jscss_version=!1,sr_detect_operaMini=navigator.userAgent.indexOf("Opera Mini")>-1;sr_detect_operaMini&&((el=document.querySelector("html")).className=el.className.concat(" operamini"));var sr_detect_firefox=navigator.userAgent.indexOf("Firefox")>-1;sr_detect_firefox&&((el=document.querySelector("html")).className=el.className.concat(" firefox"));var sr_detect_firefoxMobile=navigator.userAgent.indexOf("Firefox")>-1&&(navigator.userAgent.indexOf("Mobile")>-1||navigator.userAgent.indexOf("Tablet")>-1);sr_detect_firefoxMobile&&((el=document.querySelector("html")).className=el.className.concat(" firefox-mobile"));var sr_detect_ie=function(){var e=window.navigator.userAgent;if(e.indexOf("Trident/7.0")>0)return 11;if(e.indexOf("Trident/6.0")>0)return 10;if(e.indexOf("Trident/5.0")>0)return 9;for(var t=3,n=document.createElement("div"),r=n.getElementsByTagName("i");n.innerHTML="\x3c!--[if gt IE "+ ++t+"]><i></i><![endif]--\x3e",r[0];);return t>4&&t}(),sr_detect_edge=!sr_detect_ie&&!!window.StyleMedia,sr_detect_safari=/Safari/.test(navigator.userAgent)&&/Apple Computer/.test(navigator.vendor),el=document.querySelector("html"),className="no-js";el.classList?el.classList.remove(className):el.className=el.className.replace(new RegExp("(^|\\b)"+className.split(" ").join("|")+"(\\b|)","gi")," "),el.className=el.className.concat(" js"),function(e,t,n){function r(e,t){return typeof e===t}function o(){return"function"!=typeof t.createElement?t.createElement(arguments[0]):M?t.createElementNS.call(t,"http://www.w3.org/2000/svg",arguments[0]):t.createElement.apply(t,arguments)}function i(){var e=t.body;return e||(e=o(M?"svg":"body"),e.fake=!0),e}function a(e,n,r,a){var s,l,c,d,u="modernizr",f=o("div"),m=i();if(parseInt(r,10))for(;r--;)c=o("div"),c.id=a?a[r]:u+(r+1),f.appendChild(c);return s=o("style"),s.type="text/css",s.id="s"+u,(m.fake?m:f).appendChild(s),m.appendChild(f),s.styleSheet?s.styleSheet.cssText=e:s.appendChild(t.createTextNode(e)),f.id=u,m.fake&&(m.style.background="",m.style.overflow="hidden",d=w.style.overflow,w.style.overflow="hidden",w.appendChild(m)),l=n(f,e),m.fake?(m.parentNode.removeChild(m),w.style.overflow=d,w.offsetHeight):f.parentNode.removeChild(f),!!l}function s(e){return e.replace(/([a-z])-([a-z])/g,function(e,t,n){return t+n.toUpperCase()}).replace(/^-/,"")}function l(e,t){return!!~(""+e).indexOf(t)}function c(e,t){return function(){return e.apply(t,arguments)}}function d(e,t,n){var o;for(var i in e)if(e[i]in t)return!1===n?e[i]:(o=t[e[i]],r(o,"function")?c(o,n||t):o);return!1}function u(e){return e.replace(/([A-Z])/g,function(e,t){return"-"+t.toLowerCase()}).replace(/^ms-/,"-ms-")}function f(t,n,r){var o;if("getComputedStyle"in e){o=getComputedStyle.call(e,t,n);var i=e.console;null!==o?r&&(o=o.getPropertyValue(r)):i&&i[i.error?"error":"log"].call(i,"getComputedStyle returning null, its possible modernizr test results are inaccurate")}else o=!n&&t.currentStyle&&t.currentStyle[r];return o}function m(t,r){var o=t.length;if("CSS"in e&&"supports"in e.CSS){for(;o--;)if(e.CSS.supports(u(t[o]),r))return!0;return!1}if("CSSSupportsRule"in e){for(var i=[];o--;)i.push("("+u(t[o])+":"+r+")");return i=i.join(" or "),a("@supports ("+i+") { #modernizr { position: absolute; } }",function(e){return"absolute"==f(e,null,"position")})}return n}function p(e,t,i,a){function c(){u&&(delete k.style,delete k.modElem)}if(a=!r(a,"undefined")&&a,!r(i,"undefined")){var d=m(e,i);if(!r(d,"undefined"))return d}for(var u,f,p,v,h,g=["modernizr","tspan","samp"];!k.style&&g.length;)u=!0,k.modElem=o(g.shift()),k.style=k.modElem.style;for(p=e.length,f=0;p>f;f++)if(v=e[f],h=k.style[v],l(v,"-")&&(v=s(v)),k.style[v]!==n){if(a||r(i,"undefined"))return c(),"pfx"!=t||v;try{k.style[v]=i}catch(e){}if(k.style[v]!=h)return c(),"pfx"!=t||v}return c(),!1}function v(e,t,n,o,i){var a=e.charAt(0).toUpperCase()+e.slice(1),s=(e+" "+N.join(a+" ")+a).split(" ");return r(t,"string")||r(t,"undefined")?p(s,t,o,i):(s=(e+" "+T.join(a+" ")+a).split(" "),d(s,t,n))}function h(e,t,r){return v(e,n,n,t,r)}var g=[],_=[],y={_version:"3.6.0",_config:{classPrefix:"",enableClasses:!0,enableJSClass:!0,usePrefixes:!0},_q:[],on:function(e,t){var n=this;setTimeout(function(){t(n[e])},0)},addTest:function(e,t,n){_.push({name:e,fn:t,options:n})},addAsyncTest:function(e){_.push({name:null,fn:e})}},x=function(){};x.prototype=y,(x=new x).addTest("cookies",function(){try{t.cookie="cookietest=1";var e=-1!=t.cookie.indexOf("cookietest=");return t.cookie="cookietest=1; expires=Thu, 01-Jan-1970 00:00:01 GMT",e}catch(e){return!1}}),x.addTest("cors","XMLHttpRequest"in e&&"withCredentials"in new XMLHttpRequest),x.addTest("history",function(){var t=navigator.userAgent;return(-1===t.indexOf("Android 2.")&&-1===t.indexOf("Android 4.0")||-1===t.indexOf("Mobile Safari")||-1!==t.indexOf("Chrome")||-1!==t.indexOf("Windows Phone")||"file:"===location.protocol)&&(e.history&&"pushState"in e.history)}),x.addTest("localstorage",function(){var e="modernizr";try{return localStorage.setItem(e,e),localStorage.removeItem(e),!0}catch(e){return!1}}),x.addTest("sessionstorage",function(){var e="modernizr";try{return sessionStorage.setItem(e,e),sessionStorage.removeItem(e),!0}catch(e){return!1}});var b=y._config.usePrefixes?" -webkit- -moz- -o- -ms- ".split(" "):["",""];y._prefixes=b;var w=t.documentElement,M="svg"===w.nodeName.toLowerCase();M||function(e,t){function n(e,t){var n=e.createElement("p"),r=e.getElementsByTagName("head")[0]||e.documentElement;return n.innerHTML="x<style>"+t+"</style>",r.insertBefore(n.lastChild,r.firstChild)}function r(){var e=b.elements;return"string"==typeof e?e.split(" "):e}function o(e){var t=x[e[_]];return t||(t={},y++,e[_]=y,x[y]=t),t}function i(e,n,r){if(n||(n=t),p)return n.createElement(e);r||(r=o(n));var i;return!(i=r.cache[e]?r.cache[e].cloneNode():g.test(e)?(r.cache[e]=r.createElem(e)).cloneNode():r.createElem(e)).canHaveChildren||h.test(e)||i.tagUrn?i:r.frag.appendChild(i)}function a(e,t){t.cache||(t.cache={},t.createElem=e.createElement,t.createFrag=e.createDocumentFragment,t.frag=t.createFrag()),e.createElement=function(n){return b.shivMethods?i(n,e,t):t.createElem(n)},e.createDocumentFragment=Function("h,f","return function(){var n=f.cloneNode(),c=n.createElement;h.shivMethods&&("+r().join().replace(/[\w\-:]+/g,function(e){return t.createElem(e),t.frag.createElement(e),'c("'+e+'")'})+");return n}")(b,t.frag)}function s(e){e||(e=t);var r=o(e);return!b.shivCSS||m||r.hasCSS||(r.hasCSS=!!n(e,"article,aside,dialog,figcaption,figure,footer,header,hgroup,main,nav,section{display:block}mark{background:#FF0;color:#000}template{display:none}")),p||a(e,r),e}function l(e){for(var t,n=e.getElementsByTagName("*"),o=n.length,i=RegExp("^(?:"+r().join("|")+")","i"),a=[];o--;)t=n[o],i.test(t.nodeName)&&a.push(t.applyElement(c(t)));return a}function c(e){for(var t,n=e.attributes,r=n.length,o=e.ownerDocument.createElement(M+":"+e.nodeName);r--;)(t=n[r]).specified&&o.setAttribute(t.nodeName,t.nodeValue);return o.style.cssText=e.style.cssText,o}function d(e){for(var t,n=e.split("{"),o=n.length,i=RegExp("(^|[\\s,>+~])("+r().join("|")+")(?=[[\\s,>+~#.:]|)","gi"),a="1"+M+"\\:2";o--;)t=n[o]=n[o].split("}"),t[t.length-1]=t[t.length-1].replace(i,a),n[o]=t.join("}");return n.join("{")}function u(e){for(var t=e.length;t--;)e[t].removeNode()}function f(e){function t(){clearTimeout(a._removeSheetTimer),r&&r.removeNode(!0),r=null}var r,i,a=o(e),s=e.namespaces,c=e.parentWindow;return!E||e.printShived?e:(void 0===s[M]&&s.add(M),c.attachEvent("onbeforeprint",function(){t();for(var o,a,s,c=e.styleSheets,u=[],f=c.length,m=Array(f);f--;)m[f]=c[f];for(;s=m.pop();)if(!s.disabled&&w.test(s.media)){try{o=s.imports,a=o.length}catch(e){a=0}for(f=0;a>f;f++)m.push(o[f]);try{u.push(s.cssText)}catch(e){}}u=d(u.reverse().join("")),i=l(e),r=n(e,u)}),c.attachEvent("onafterprint",function(){u(i),clearTimeout(a._removeSheetTimer),a._removeSheetTimer=setTimeout(t,500)}),e.printShived=!0,e)}var m,p,v=e.html5||{},h=/^<|^(?:button|map|select|textarea|object|iframe|option|optgroup)/i,g=/^(?:a|b|code|div|fieldset|h1|h2|h3|h4|h5|h6|i|label|li|ol|p|q|span|strong|style|table|tbody|td|th|tr|ul)/i,_="_html5shiv",y=0,x={};!function(){try{var e=t.createElement("a");e.innerHTML="<xyz></xyz>",m="hidden"in e,p=1==e.childNodes.length||function(){t.createElement("a");var e=t.createDocumentFragment();return void 0===e.cloneNode||void 0===e.createDocumentFragment||void 0===e.createElement}()}catch(e){m=!0,p=!0}}();var b={elements:v.elements||"abbr article aside audio bdi canvas data datalist details dialog figcaption figure footer header hgroup main mark meter nav output picture progress section summary template time video",version:"3.7.3",shivCSS:!1!==v.shivCSS,supportsUnknownElements:p,shivMethods:!1!==v.shivMethods,type:"default",shivDocument:s,createElement:i,createDocumentFragment:function(e,n){if(e||(e=t),p)return e.createDocumentFragment();for(var i=(n=n||o(e)).frag.cloneNode(),a=0,s=r(),l=s.length;l>a;a++)i.createElement(s[a]);return i},addElements:function(e,t){var n=b.elements;"string"!=typeof n&&(n=n.join(" ")),"string"!=typeof e&&(e=e.join(" ")),b.elements=n+" "+e,s(t)}};e.html5=b,s(t);var w=/^|\b(?:all|print)\b/,M="html5shiv",E=!p&&function(){var n=t.documentElement;return!(void 0===t.namespaces||void 0===t.parentWindow||void 0===n.applyElement||void 0===n.removeNode||void 0===e.attachEvent)}();b.type+=" print",b.shivPrint=f,f(t),"object"==typeof module&&module.exports&&(module.exports=b)}(void 0!==e?e:this,t),x.addTest("canvas",function(){var e=o("canvas");return!(!e.getContext||!e.getContext("2d"))});var E=function(){var e=!("onblur"in t.documentElement);return function(t,r){var i;return!!t&&(r&&"string"!=typeof r||(r=o(r||"div")),t="on"+t,!(i=t in r)&&e&&(r.setAttribute||(r=o("div")),r.setAttribute(t,""),i="function"==typeof r[t],r[t]!==n&&(r[t]=n),r.removeAttribute(t)),i)}}();y.hasEvent=E;var S=y.testStyles=a;x.addTest("touchevents",function(){var n;if("ontouchstart"in e||e.DocumentTouch&&t instanceof DocumentTouch)n=!0;else{var r=["@media (",b.join("touch-enabled),("),"heartz",")","{#modernizr{top:9px;position:absolute}}"].join("");S(r,function(e){n=9===e.offsetTop})}return n}),x.addTest("unicode",function(){var e,t=o("span"),n=o("span");return S("#modernizr{font-family:Arial,sans;font-size:300em;}",function(r){t.innerHTML=M?"妇":"&#5987;",n.innerHTML=M?"☆":"&#9734;",r.appendChild(t),r.appendChild(n),e="offsetWidth"in t&&t.offsetWidth!==n.offsetWidth}),e});var z="Moz O ms Webkit",T=y._config.usePrefixes?z.toLowerCase().split(" "):[];y._domPrefixes=T,x.addTest("pointerevents",function(){var e=!1,t=T.length;for(e=x.hasEvent("pointerdown");t--&&!e;)E(T[t]+"pointerdown")&&(e=!0);return e});var N=y._config.usePrefixes?z.split(" "):[];y._cssomPrefixes=N;var C=function(t){var r,o=b.length,i=e.CSSRule;if(void 0===i)return n;if(!t)return!1;if(t=t.replace(/^@/,""),(r=t.replace(/-/g,"_").toUpperCase()+"_RULE")in i)return"@"+t;for(var a=0;o>a;a++){var s=b[a];if(s.toUpperCase()+"_"+r in i)return"@-"+s.toLowerCase()+"-"+t}return!1};y.atRule=C;var L={elem:o("modernizr")};x._q.push(function(){delete L.elem});var k={style:L.elem.style};x._q.unshift(function(){delete k.style}),y.testAllProps=v;var j=y.prefixed=function(e,t,n){return 0===e.indexOf("@")?C(e):(-1!=e.indexOf("-")&&(e=s(e)),t?v(e,t,n):v(e,"pfx"))};x.addTest("vibrate",!!j("vibrate",navigator)),x.addTest("matchmedia",!!j("matchMedia",e)),y.testAllProps=h,x.addTest("flexwrap",h("flexWrap","wrap",!0)),function(){var e,t,n,o,i,a,s;for(var l in _)if(_.hasOwnProperty(l)){if(e=[],(t=_[l]).name&&(e.push(t.name.toLowerCase()),t.options&&t.options.aliases&&t.options.aliases.length))for(n=0;n<t.options.aliases.length;n++)e.push(t.options.aliases[n].toLowerCase());for(o=r(t.fn,"function")?t.fn():t.fn,i=0;i<e.length;i++)a=e[i],1===(s=a.split(".")).length?x[s[0]]=o:(!x[s[0]]||x[s[0]]instanceof Boolean||(x[s[0]]=new Boolean(x[s[0]])),x[s[0]][s[1]]=o),g.push((o?"":"no-")+s.join("-"))}}(),function(e){var t=w.className,n=x._config.classPrefix||"";if(M&&(t=t.baseVal),x._config.enableJSClass){var r=new RegExp("(^|\\s)"+n+"no-js(\\s|)");t=t.replace(r,"1"+n+"js2")}x._config.enableClasses&&(t+=" "+n+e.join(" "+n),M?w.className.baseVal=t:w.className=t)}(g),delete y.addTest,delete y.addAsyncTest;for(var A=0;A<x._q.length;A++)x._q[A]();e.Modernizr=x}(window,document),Modernizr.viewport_width=Math.max(document.documentElement.clientWidth,window.innerWidth||0),Modernizr.viewport_height=Math.max(document.documentElement.clientHeight,window.innerHeight||0),Modernizr.narrow=Modernizr.viewport_width<=704,Modernizr.constrained=Modernizr.viewport_width<=1200,Modernizr.site_menu=Modernizr.viewport_width<=1020?"button":"nav_bar",Modernizr.touch=Modernizr.touchevents||Modernizr.pointerevents&&(navigator.MaxTouchPoints>0||navigator.msMaxTouchPoints>0),Modernizr.phone=Modernizr.narrow&&Modernizr.touch,Modernizr.tablet=Modernizr.viewport_width<1075&&Modernizr.touch,Modernizr.desktop=!Modernizr.constrained&&!Modernizr.touch,Modernizr.laptop=!(Modernizr.desktop||Modernizr.tablet||Modernizr.phone);var patt=new RegExp("hideallads");Modernizr.adfree=patt.test(window.location.href);var sr_html=document.querySelector("html"),cn=sr_html.className;Modernizr.phone?sr_html.className=cn.concat(" phone"):Modernizr.tablet?sr_html.className=cn.concat(" tablet"):(Modernizr.desktop||Modernizr.laptop)&&(sr_html.className=cn.concat(" desktop"));var sr_host_parts=window.location.hostname.split("."),cn=sr_html.className;Modernizr.is_build=Modernizr.is_live=Modernizr.is_dev=!1,"b"===sr_host_parts[0]?(Modernizr.is_build=!0,sr_html.className=cn.concat(" is_build")):"d"===sr_host_parts[0]||"r"===sr_host_parts[0]?(Modernizr.is_dev=!0,sr_html.className=cn.concat(" is_dev")):"www"===sr_host_parts[0]&&(Modernizr.is_live=!0,sr_html.className=cn.concat(" is_live"));var sr_logger=function(){var e=null,t={};return t.enableLogger=function(){null!=e&&(window.console.log=e)},t.disableLogger=function(){e=console.log,window.console.log=function(){}},t}();sr_is_production&&sr_logger.disableLogger(),Modernizr.is_modern=(Modernizr.canvas||Modernizr.localstorage)&&!sr_detect_operaMini,Modernizr.is_modern?(document.documentElement.className+=" is_modern",Modernizr.is_not_modern=!1):(document.documentElement.className+=" is_not_modern",Modernizr.is_not_modern=!0);var sr_utilities_js_loader=[];!function(e){var t=function(t,n){"use strict";var r=e.document.getElementsByTagName("script")[0],o=e.document.createElement("script");return o.src=t,o.async=!0,r.parentNode.insertBefore(o,r),n&&"function"==typeof n&&(o.onload=n),o};"undefined"!=typeof module?module.exports=t:e.loadJS=t}("undefined"!=typeof global?global:this),function(e){"use strict";var t=function(t,n,r){function o(e){if(s.body)return e();setTimeout(function(){o(e)})}function i(){l.addEventListener&&l.removeEventListener("load",i),l.media=r||"all"}var a,s=e.document,l=s.createElement("link");if(n)a=n;else{var c=(s.body||s.getElementsByTagName("head")[0]).childNodes;a=c[c.length-1]}var d=s.styleSheets;l.rel="stylesheet",l.href=t,l.media="only x",o(function(){a.parentNode.insertBefore(l,n?a:a.nextSibling)});var u=function(e){for(var t=l.href,n=d.length;n--;)if(d[n].href===t)return e();setTimeout(function(){u(e)})};return l.addEventListener&&l.addEventListener("load",i),l.onloadcssdefined=u,u(i),l};"undefined"!=typeof exports?exports.loadCSS=t:e.loadCSS=t}("undefined"!=typeof global?global:this),function(e){if(e.loadCSS){var t=loadCSS.relpreload={};if(t.support=function(){try{return e.document.createElement("link").relList.supports("preload")}catch(e){return!1}},t.poly=function(){for(var t=e.document.getElementsByTagName("link"),n=0;n<t.length;n++){var r=t[n];"preload"===r.rel&&"style"===r.getAttribute("as")&&(e.loadCSS(r.href,r,r.getAttribute("media")),r.rel=null)}},!t.support()){t.poly();var n=e.setInterval(t.poly,300);e.addEventListener&&e.addEventListener("load",function(){t.poly(),e.clearInterval(n)}),e.attachEvent&&e.attachEvent("onload",function(){e.clearInterval(n)})}}}(this);var sr_time_begin=new Date,sr_perf_startTime=new Date,sr_perf_log="<strong>Performance:</strong>",sr_perf_lastTime=new Date;
-
-</script>
-
-<script>
-if (Modernizr.is_modern) { loadJS( "https://d2p3bygnnzw9w3.cloudfront.net/req/201812041/js/bbr/sr-min.js"     , function() { vjs_ready(sr_fire_js); }); }
-else                     { loadJS( "https://d2p3bygnnzw9w3.cloudfront.net/req/201812041/js/bbr/sr-basic-min.js", function() { vjs_ready(sr_fire_js); }); }
-</script>
-
 
 
     <title>San Antonio Spurs at Atlanta Hawks Box Score, January 1, 2017 | Basketball-Reference.com</title>
-    <meta name="revised" content="18:44:08 28-Dec-2018" />
+    <meta name="revised" content="19:18:12 27-Sep-2019" />
     <meta name="HandheldFriendly" content="True" />
     <meta name="HandheldFriendly" content="True" />
     <meta name="generated-by"     content="build_box_score_pages.pl" />
     <meta name="format-detection" content="telephone=no" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="no" />
     <meta name="theme-color" content="#4d4438" />
     <meta name="msapplication-navbutton-color" content="#4d4438" />
     <meta name="apple-mobile-web-app-status-bar-style" content="#4d4438" />
 
 
 <meta name="keywords" content="stats, NBA, box score">
-    <link rel="canonical" href="https://www.basketball-reference.com/boxscores/201701010ATL.html" />
-
-<meta itemprop="url"           content="https://www.basketball-reference.com">
+    <link rel="canonical" href="https://www.basketball-reference.com/boxscores/201701010ATL.html" /><meta itemprop="url"           content="https://www.basketball-reference.com">
     <meta itemprop="name"          content="Basketball Reference">
     <meta itemprop="alternateName" content="BkRef">
     <meta name="Description" content="Box Score - San Antonio Spurs (112) vs. Atlanta Hawks (114) - January 1, 2017">
@@ -57,34 +62,34 @@ else                     { loadJS( "https://d2p3bygnnzw9w3.cloudfront.net/req/20
     <meta property="og:site_name"    content="Basketball-Reference.com">
     <meta property="og:type"         content="    article" />
     <meta property="og:description"  content="Box Score - San Antonio Spurs (112) vs. Atlanta Hawks (114) - January 1, 2017">
-    <meta property="og:image"        content="http://ssref.net/scripts/image_resize.cgi?foo=bar&flat=0&url1=https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/tlogo/bbr/SAS-2017.png&url2=https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/tlogo/bbr/ATL-2017.png">
+    <meta property="og:image"        content="http://ssref.net/scripts/image_resize.cgi?foo=bar&flat=0&url1=https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/tlogo/bbr/SAS-2017.png&url2=https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/tlogo/bbr/ATL-2017.png">
 <meta name="twitter:card"         content="summary">
     <meta name="twitter:site"         content="@bball_ref">
     <meta name="twitter:creator"      content="@bball_ref">
-    <meta property="twitter:image"    content="http://ssref.net/scripts/image_resize.cgi?foo=bar&flat=0&url1=https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/tlogo/bbr/SAS-2017.png&url2=https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/tlogo/bbr/ATL-2017.png">
+    <meta property="twitter:image"    content="http://ssref.net/scripts/image_resize.cgi?foo=bar&flat=0&url1=https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/tlogo/bbr/SAS-2017.png&url2=https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/tlogo/bbr/ATL-2017.png">
     <meta name="twitter:domain"       content="Basketball-Reference.com">
     <meta name="referrer" content="unsafe-url">
 
 
     <!-- tiles, touch, favicons -->
-    <link rel="icon"                         sizes="192x192" href="https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/favicons/bbr/apple-touch-icon-192x192-precomposed.png">
-    <link rel="apple-touch-icon"             sizes="228x228" href="https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/favicons/bbr/apple-touch-icon-228x228-precomposed.png">
-    <link rel="apple-touch-icon"             sizes="195x195" href="https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/favicons/bbr/apple-touch-icon-195x195-precomposed.png">
-    <link rel="apple-touch-icon"             sizes="180x180" href="https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/favicons/bbr/apple-touch-icon-180x180-precomposed.png">
-    <link rel="apple-touch-icon"             sizes="152x152" href="https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/favicons/bbr/apple-touch-icon-152x152-precomposed.png">
-    <link rel="apple-touch-icon"             sizes="144x144" href="https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/favicons/bbr/apple-touch-icon-144x144-precomposed.png">
-    <link rel="apple-touch-icon"             sizes="128x128" href="https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/favicons/bbr/apple-touch-icon-128x128-precomposed.png">
-    <link rel="apple-touch-icon"             sizes="120x120" href="https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/favicons/bbr/apple-touch-icon-120x120-precomposed.png">
-    <link rel="apple-touch-icon"             sizes="114x114" href="https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/favicons/bbr/apple-touch-icon-114x114-precomposed.png">
-    <link rel="apple-touch-icon"             sizes="76x76"   href="https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/favicons/bbr/apple-touch-icon-76x76-precomposed.png">
-    <link rel="apple-touch-icon"             sizes="72x72"   href="https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/favicons/bbr/apple-touch-icon-72x72-precomposed.png">
-    <link rel="apple-touch-icon"             sizes="57x57"   href="https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/favicons/bbr/apple-touch-icon-57x57-precomposed.png">
-    <link rel="icon"                         sizes="32x32"   href="https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/favicons/bbr/favicon-32.png">
+    <link rel="icon"                         sizes="192x192" href="https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/favicons/bbr/apple-touch-icon-192x192-precomposed.png">
+    <link rel="apple-touch-icon"             sizes="228x228" href="https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/favicons/bbr/apple-touch-icon-228x228-precomposed.png">
+    <link rel="apple-touch-icon"             sizes="195x195" href="https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/favicons/bbr/apple-touch-icon-195x195-precomposed.png">
+    <link rel="apple-touch-icon"             sizes="180x180" href="https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/favicons/bbr/apple-touch-icon-180x180-precomposed.png">
+    <link rel="apple-touch-icon"             sizes="152x152" href="https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/favicons/bbr/apple-touch-icon-152x152-precomposed.png">
+    <link rel="apple-touch-icon"             sizes="144x144" href="https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/favicons/bbr/apple-touch-icon-144x144-precomposed.png">
+    <link rel="apple-touch-icon"             sizes="128x128" href="https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/favicons/bbr/apple-touch-icon-128x128-precomposed.png">
+    <link rel="apple-touch-icon"             sizes="120x120" href="https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/favicons/bbr/apple-touch-icon-120x120-precomposed.png">
+    <link rel="apple-touch-icon"             sizes="114x114" href="https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/favicons/bbr/apple-touch-icon-114x114-precomposed.png">
+    <link rel="apple-touch-icon"             sizes="76x76"   href="https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/favicons/bbr/apple-touch-icon-76x76-precomposed.png">
+    <link rel="apple-touch-icon"             sizes="72x72"   href="https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/favicons/bbr/apple-touch-icon-72x72-precomposed.png">
+    <link rel="apple-touch-icon"             sizes="57x57"   href="https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/favicons/bbr/apple-touch-icon-57x57-precomposed.png">
+    <link rel="icon"                         sizes="32x32"   href="https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/favicons/bbr/favicon-32.png">
     <!--[if IE]>
-    <link rel="shortcut icon"                                href="https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/favicons/bbr/favicon.ico"><![endif]-->
+    <link rel="shortcut icon"                                href="https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/favicons/bbr/favicon.ico"><![endif]-->
     <meta name="msapplication-TileColor" content="#905500" />
-    <meta name="msapplication-TileImage" content="https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/favicons/bbr/ms-tile-144.png" />
-    <link rel=search        type="application/opensearchdescription+xml" href="https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/opensearch/opensearch-bbr.xml" title=" Player and Team Search">
+    <meta name="msapplication-TileImage" content="https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/favicons/bbr/ms-tile-144.png" />
+    <link rel=search        type="application/opensearchdescription+xml" href="https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/opensearch/opensearch-bbr.xml" title=" Player and Team Search">
 
 
 
@@ -138,8 +143,9 @@ else                     { loadJS( "https://d2p3bygnnzw9w3.cloudfront.net/req/20
 <body class="bbr"	     >
 
 <div id="wrap">
+
   <div id="header" role="banner">
-  <ul id="subnav">
+  <ul id="subnav" class="notranslate">
 	<li><a href="https://www.sports-reference.com/"><svg height="15px" width="20px"><use xlink:href="#ic-sr-pennant"></use></svg> Sports Reference</a></li>
 	<li><a href="https://www.baseball-reference.com/">Baseball</a></li>
 	<li><a href="https://www.pro-football-reference.com/">Football</a> <a href="https://www.sports-reference.com/cfb/">(college)</a></li>
@@ -152,7 +158,7 @@ else                     { loadJS( "https://d2p3bygnnzw9w3.cloudfront.net/req/20
         <li><a href="https://widgets.sports-reference.com/">Widgets</a></li>
 
         	<li><a href="https://www.sports-reference.com/feedback/">Questions or Comments?</a></li>
-	<li class="user logged_in">Welcome<span class="username"></span>&nbsp;&#183;&nbsp;<a href="/my/">Your Account</a></li>
+	<li class="user logged_in">Welcome <span class="username"></span>&nbsp;&#183;&nbsp;<a href="/my/">Your Account</a></li>
 <li class="user logged_in"><a class="logout" href="/my/?do=logout">Logout</a></li>
 <li class="user not_logged_in"><a class="login" href="/my/">Login</a></li>
 <li class="user not_logged_in"><a href="/my/">Create Account</a></li>
@@ -160,7 +166,7 @@ else                     { loadJS( "https://d2p3bygnnzw9w3.cloudfront.net/req/20
 
 </ul>
 
-  <a href="/"><img src="https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/logos/bbr-logo.svg" onerror="this.src='https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/logos/bbr-logo.png'; this.onerror = null;" alt="Basketball-Reference.com Logo &amp; Link to home page" /></a>
+  <a href="/"><img src="https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/logos/bbr-logo.svg" onerror="this.src='https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/logos/bbr-logo.png'; this.onerror = null;" alt="Basketball-Reference.com Logo &amp; Link to home page" /></a>
 <div id="nav_trigger" role="button"><a href="#site_menu_link">MENU</a></div>
 <div id="nav" role="navigation" aria-label="Basketball-Reference.com sections">
 	<ul id="main_nav" class="hoversmooth nohover"><li id="header_players" ><a href="/players/">Players</a></li>
@@ -173,8 +179,8 @@ else                     { loadJS( "https://d2p3bygnnzw9w3.cloudfront.net/req/20
 <li id="header_playindex" class=""><a href="/play-index/">Play Index</a></li>
 <li><a data-scroll href="#site_menu_link" class="opener">Full Site Menu Below</a></li>
 	</ul>
-	<div class="breadcrumbs">You are here: <div itemscope itemtype="https://schema.org/BreadcrumbList" class="crumbs"><span><a href="/">BBR Home</a></span> &gt; <span itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><a itemprop="item" href="/boxscores/index.cgi?month=1&amp;day=1&amp;year=2017"><span itemprop="name">Box Scores</span></a> <meta itemprop="position" content="1" /></span> &gt; <span itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><strong><span itemprop="name">San Antonio Spurs at Atlanta Hawks Box Score, January 1, 2017</span></strong> <meta itemprop="position" content="2" /></span></div></div>
-	<ul class="usertools bullets-inline"><li class="user logged_in">Welcome<span class="username"></span>&nbsp;&#183;&nbsp;<a href="/my/">Your Account</a></li>
+	<div class="breadcrumbs">You are here: <div itemscope itemtype="https://schema.org/BreadcrumbList" class="crumbs"><span><a href="/">BBR Home Page</a></span> &gt; <span itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><a itemprop="item" href="/boxscores/index.cgi?month=1&amp;day=1&amp;year=2017"><span itemprop="name">Box Scores</span></a> <meta itemprop="position" content="1" /></span> &gt; <strong>San Antonio Spurs at Atlanta Hawks Box Score, January 1, 2017</strong></div></div>
+	<ul class="usertools bullets-inline"><li class="user logged_in">Welcome <span class="username"></span>&nbsp;&#183;&nbsp;<a href="/my/">Your Account</a></li>
 <li class="user logged_in"><a class="logout" href="/my/?do=logout">Logout</a></li>
 <li class="user not_logged_in"><a class="login" href="/my/">Login</a></li>
 <li class="user not_logged_in"><a href="/my/">Create Account</a></li>
@@ -213,13 +219,16 @@ function sr_menus_setupMainNav_button_inline () {
 }
 sr_menus_setupMainNav_button_inline();
 </script><div class="search" role="search" aria-label="Site Search for players, teams and sections">
-<form itemprop="potentialAction" itemscope itemtype="https://schema.org/SearchAction" name="f_big"  action="/search/search.fcgi">
+<form method="get" itemprop="potentialAction" itemscope itemtype="https://schema.org/SearchAction" name="f_big"  action="/search/search.fcgi">
 <meta itemprop="target" content="https://www.basketball-reference.com/search/search.fcgi?search={search}">
 <div class="ac-outline">
-  <div class="ac-wrapper"><input type="search" tabindex="-1" class="ac-hint" name="hint" placeholder="" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" dir="auto"><input tabindex="1" type="search" class="ac-input completely" name="search" placeholder="Enter Person, Team, Section, etc" aria-label="Enter a player, team or section name" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" dir="auto" itemprop="query-input" />
+  <div class="ac-wrapper"><input type="search" tabindex="-1" class="ac-hint" name="hint" placeholder="" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" dir="auto">
+
+<input tabindex="1" type="search" class="ac-input completely" name="search" placeholder="Enter Person, Team, Section, etc" aria-label="Enter a player, team or section name" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" dir="auto" itemprop="query-input" />
     <div class="ac-dropdown"></div>
   </div>
 </div>
+
 <input type="submit" value="Search" tabindex="2" />
 <input type="hidden" name="pid" value="" data-search-id>
 <input type="hidden" name="idx" value="" data-search-idx>
@@ -254,8 +263,8 @@ sr_menus_setupMainNav_button_inline();
 </div>
 <div id="inner_nav" role="navigation" aria-label="Sections on this page and/or other pages related to this page" class=" inactive suppress_inpage_nav">
 	<ul class="hoversmooth">
-		<li		   class="index "><a href="/boxscores/"><u>NBA Jan 1, 2017 Scores & Boxes</u></a>		</li>
-		<li		   class="full "><a href="/leagues/NBA_2017_games.html"><u>2016-17 NBA Scores & Schedule</u></a>		</li>
+		<li		   class="index "><a href="/boxscores/"><u>Jan 1, 2017 NBA Scores & Boxes</u></a>		</li>
+		<li		   class="full "><a href="/leagues/NBA_2017_games.html"><u>2016-17 NBA Schedule & Results</u></a>		</li>
 		<li		   class="full "><a href="/teams/SAS/2017_games.html"><u>San Antonio Spurs Schedule</u></a>		</li>
 		<li		   class="full "><a href="/teams/ATL/2017_games.html"><u>Atlanta Hawks Schedule</u></a>		</li>
 		<li data-fade-selector="#inpage_nav"		   class="condensed hasmore "><span>Team and League Schedules</span>
@@ -264,7 +273,7 @@ sr_menus_setupMainNav_button_inline();
 					<ul class=" in_list">
 						<li><a href="/teams/SAS/2017_games.html"><u>San Antonio Spurs Schedule</u></a></li>
 						<li><a href="/teams/ATL/2017_games.html"><u>Atlanta Hawks Schedule</u></a></li>
-						<li><a href="/leagues/NBA_2017_games.html"><u>2016-17 NBA Scores & Schedule</u></a></li>
+						<li><a href="/leagues/NBA_2017_games.html"><u>2016-17 NBA Schedule & Results</u></a></li>
 					</ul>
 
 			</div>		</li>
@@ -277,9 +286,8 @@ sr_menus_setupMainNav_button_inline();
 <div class="section_heading">
   <span class="section_anchor" id="other_scores_link" data-label="All Games This Date"></span><h2></h2>
 </div><div class="placeholder"></div>
-<!--
-    <div class="section_content" id="div_other_scores">
-<div class="game_summaries compressed">
+<!--     <div class="section_content" id="div_other_scores">
+	    <div class="game_summaries compressed">
    <h2>NBA Scores &mdash; Jan 1, 2017</h2>
 
       <div class="game_summary nohover current">
@@ -400,31 +408,35 @@ sr_menus_setupMainNav_button_inline();
 
 </div>
 
-    </div>
 
+    </div>
 -->
 </div>
 
 
 
 <div class="scorebox">
-      <div>
+	<div>
 		<div itemscope="" itemprop="performer" itemtype="https://schema.org/Organization">
 
-<div class="media-item logo loader">
-	<img class="teamlogo" itemscope="image" 	     src="https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/tlogo/bbr/SAS-2017.png"
-	     alt="2017 San Antonio Spurs Logo">
 
-	<p><a href="http://www.sportslogos.net/">via Sports Logos.net</a></p>
-	<p><a href="https://www.sports-reference.com/blog/2016/06/redesign-team-and-league-logos-courtesy-sportslogos-net/">About logos</a></p>
+	<div class="media-item logo loader">
+		<img class="teamlogo" itemscope="image" 			src="https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/tlogo/bbr/SAS-2017.png"
+			alt="2017 San Antonio Spurs Logo">
 
-</div>
+			<p><a href="http://www.sportslogos.net/">via Sports Logos.net</a></p>
+			<p><a href="https://www.sports-reference.com/blog/2016/06/redesign-team-and-league-logos-courtesy-sportslogos-net/">About logos</a></p>
+
+	</div>
+
 
 <strong>
 				<a href="/teams/SAS/2017.html" itemprop="name">San Antonio Spurs</a>
 			</strong>
 		</div>
-		<div class="score">112</div><div>27-7</div>
+		<div class="scores">
+			<div class="score">112</div>
+		</div><div>27-7</div>
 			<div class="prevnext">
 
   <a href="/boxscores/201612300SAS.html" class="button2 prev">Prev Game</a>
@@ -435,24 +447,28 @@ sr_menus_setupMainNav_button_inline();
 </div>
 
 
-		</div>
-      <div>
+	</div>
+	<div>
 		<div itemscope="" itemprop="performer" itemtype="https://schema.org/Organization">
 
-<div class="media-item logo loader">
-	<img class="teamlogo" itemscope="image" 	     src="https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/tlogo/bbr/ATL-2017.png"
-	     alt="2017 Atlanta Hawks Logo">
 
-	<p><a href="http://www.sportslogos.net/">via Sports Logos.net</a></p>
-	<p><a href="https://www.sports-reference.com/blog/2016/06/redesign-team-and-league-logos-courtesy-sportslogos-net/">About logos</a></p>
+	<div class="media-item logo loader">
+		<img class="teamlogo" itemscope="image" 			src="https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/tlogo/bbr/ATL-2017.png"
+			alt="2017 Atlanta Hawks Logo">
 
-</div>
+			<p><a href="http://www.sportslogos.net/">via Sports Logos.net</a></p>
+			<p><a href="https://www.sports-reference.com/blog/2016/06/redesign-team-and-league-logos-courtesy-sportslogos-net/">About logos</a></p>
+
+	</div>
+
 
 <strong>
 				<a href="/teams/ATL/2017.html" itemprop="name">Atlanta Hawks</a>
 			</strong>
 		</div>
-		<div class="score">114</div><div>18-16</div>
+		<div class="scores">
+			<div class="score">114</div>
+		</div><div>18-16</div>
 			<div class="prevnext">
 
   <a href="/boxscores/201612300ATL.html" class="button2 prev">Prev Game</a>
@@ -463,15 +479,65 @@ sr_menus_setupMainNav_button_inline();
 </div>
 
 
-		</div>
+	</div>
 
-		<div class="scorebox_meta">
+	<div class="scorebox_meta">
 		<div>6:00 PM, January 1, 2017</div><div>Philips Arena, Atlanta, Georgia</div>
 		<div><em>Logos <a href="http://www.sportslogos.net/">via Sports Logos.net</a>
             / <a href="//www.sports-reference.com/blog/2016/06/redesign-team-and-league-logos-courtesy-sportslogos-net/">About logos</a></em></div>
 	</div>
 
+
 </div>
+
+
+
+
+<style>
+.fb .scorebox { position: relative; max-width: 640px; }
+.fb .scorebox > div:first-child .scores > div:after { position: absolute; left: 0; content: ':'; width: 100%; }
+.fb .scorebox .scorebox_meta { margin-top: 10px; }
+.fb .scorebox .score { font-size: 1.9em; font-weight: 800; }
+.fb .scorebox .score_pen, .fb .scorebox .score_aggr { font-size: 1.28em; font-weight: bold; margin-top: 12px; }
+.fb .scorebox > div:first-child .score_pen:before, .fb .scorebox > div:first-child .score_aggr:before {
+	position: absolute;
+	width: 100%;
+	left: 0;
+	margin-top: -11px;
+	color: #777;
+	font-size: 13px;
+	font-weight: bold;
+}
+.fb .scorebox > div:first-child .score_pen:before  { content: 'Penalties'; }
+.fb .scorebox > div:first-child .score_aggr:before { content: 'Aggregate'; }
+
+@media screen and (min-width: 470px) {
+	.fb .scorebox .prevnext { min-width: 200px; }
+}
+
+@media screen and (min-width: 800px) {
+	.fb .scorebox                   .scores  { position: absolute; top: 35px; left: 0; }
+	.fb .scorebox > div:first-child .scores  { left: auto; right: 0; }
+
+	.fb .scorebox .scores > div       { padding: 0 10px; }
+	.fb .scorebox > div:first-child .scores > div:after { width: 200%; }
+
+	.fb .scorebox .score { font-size: 2.7em; }
+
+	.fb .scorebox .score_pen, .fb .scorebox .score_aggr { margin-top: 17px; }
+
+	.fb .scorebox > div:first-child .score_pen:before, .fb .scorebox > div:first-child .score_aggr:before { width: 200%; margin-top: -15px; }
+
+	.fb .scorebox > div { padding: 0 8%; position: relative; }
+	.fb .scorebox .event { position: absolute; padding: 0; top: 15px; right: -160px; text-align: left; }
+	.fb .scorebox .event#a { text-align: right; left: -160px; right: auto; }
+	.fb .scorebox .event > div { margin-bottom: 6px; }
+}
+
+@media screen and (max-width: 1020px) {
+	.fb .scorebox .event { display: none; }
+}
+</style>
 
 
 
@@ -501,7 +567,16 @@ sr_menus_setupMainNav_button_inline();
 
 
 
-      <!-- no Local/Partials/NoteTop.tt2 -->
+      <div class="callout light"><h3><a href="https://stathead.com/?utm_medium=sr&amp;utm_source=bbr&amp;utm_campaign=bbr-2019-09-23">Are You a Stathead?</a></h3>
+
+<p>Be ready when the games start.  Every day, we'll send you an email to your inbox with scores,
+today's schedule, top performers, new debuts and interesting facts and tidbits.
+View a <a
+href="https://us1.campaign-archive.com/?u=3a312748c8b8131b261229cf8&id=a40603a996">sample
+email</a>.  It's also available for football, hockey and
+baseball.</p>
+
+<p><a href="https://stathead.com/?utm_medium=sr&amp;utm_source=bbr&amp;utm_campaign=bbr-2019-03-18">Subscribe to our Stathead Newsletter</a></p></div>
 
 
 
@@ -517,13 +592,21 @@ sr_menus_setupMainNav_button_inline();
 		<a href="/boxscores/plus-minus/201701010ATL.html">Plus/Minus</a>
 	</div></div>
 
-<div id="all_line_score" class="table_wrapper floated setup_commented commented">
+
+
+
+
+
+            <div class="content_grid">
+<div>
+<div id="all_line_score" class="table_wrapper setup_commented commented">
 
 <div class="section_heading">
   <span class="section_anchor" id="line_score_link" data-label="Line Score"></span><h2>Line Score</h2>    <div class="section_heading_text">
       <ul>
       </ul>
     </div>
+
 </div>
 <div class="placeholder"></div>
 <!--
@@ -567,14 +650,15 @@ sr_menus_setupMainNav_button_inline();
    </div>
 -->
 </div>
-
-<div id="all_four_factors" class="table_wrapper floated setup_commented commented">
+</div><div>
+<div id="all_four_factors" class="table_wrapper setup_commented commented">
 
 <div class="section_heading">
   <span class="section_anchor" id="four_factors_link" data-label="Four Factors"></span><h2>Four Factors</h2>    <div class="section_heading_text">
       <ul>
       </ul>
     </div>
+
 </div>
 <div class="placeholder"></div>
 <!--
@@ -609,18 +693,27 @@ sr_menus_setupMainNav_button_inline();
    </div>
 -->
 </div>
-<div class='section_wrapper'></div>
+</div>
+</div>
 
-<div id="all_box_sas_basic" class="table_wrapper">
+
+
+
+
+
+            <div><button class='sr_preset tooltip' data-hide='.box-SAS' data-show='.box-SAS-game'>Game</button>&nbsp;&#183; <button class='sr_preset tooltip' data-hide='.box-SAS' data-show='.box-SAS-q1'>Q1</button>&nbsp;&#183; <button class='sr_preset tooltip' data-hide='.box-SAS' data-show='.box-SAS-q2'>Q2</button>&nbsp;&#183; <button class='sr_preset tooltip' data-hide='.box-SAS' data-show='.box-SAS-h1'>H1</button>&nbsp;&#183; <button class='sr_preset tooltip' data-hide='.box-SAS' data-show='.box-SAS-q3'>Q3</button>&nbsp;&#183; <button class='sr_preset tooltip' data-hide='.box-SAS' data-show='.box-SAS-q4'>Q4</button>&nbsp;&#183; <button class='sr_preset tooltip' data-hide='.box-SAS' data-show='.box-SAS-h2'>H2</button>&nbsp;&#183; <button class='sr_preset tooltip' data-hide='.box-SAS' data-show='.box-SAS-q5'>Q5</button></div><div class="section_wrapper box-SAS box-SAS-game" id="all_box-SAS-game-basic">    <div class="section_content" id="div_box-SAS-game-basic">
+
+<div id="all_box-SAS-game-basic" class="table_wrapper">
 
 <div class="section_heading">
-  <span class="section_anchor" id="box_sas_basic_link" data-label="San Antonio Spurs (27-7)"></span><h2>San Antonio Spurs (27-7)</h2>    <div class="section_heading_text">
+  <span class="section_anchor" id="box-SAS-game-basic_link" data-label="San Antonio Spurs (27-7)"></span><h2>San Antonio Spurs (27-7)</h2>    <div class="section_heading_text">
       <ul>
       </ul>
     </div>
+
 </div>   <div class="table_outer_container">
-      <div class="overthrow table_container" id="div_box_sas_basic">
-  <table class="sortable stats_table" id="box_sas_basic" data-cols-to-freeze=1><caption>San Antonio Spurs (27-7) Table</caption>
+      <div class="overthrow table_container" id="div_box-SAS-game-basic">
+  <table class="sortable stats_table" id="box-SAS-game-basic" data-cols-to-freeze=1><caption>San Antonio Spurs (27-7) Table</caption>
    <colgroup><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col></colgroup>
    <thead>
 
@@ -688,13 +781,13 @@ sr_menus_setupMainNav_button_inline();
 
 
 <tr ><th scope="row" class="left " data-append-csv="millspa02" data-stat="player" csk="Mills,Patty" ><a href="/players/m/millspa02.html">Patty Mills</a></th><td class="right " data-stat="mp" csk="1274" >21:14</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >8</td><td class="right " data-stat="fg_pct" >.250</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >4</td><td class="right " data-stat="fg3_pct" >.250</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right " data-stat="ast" >3</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >5</td><td class="right " data-stat="plus_minus" >-3</td></tr>
-<tr ><th scope="row" class="left " data-append-csv="ginobma01" data-stat="player" csk="Ginobili,Manu" ><a href="/players/g/ginobma01.html">Manu Ginobili</a></th><td class="right " data-stat="mp" csk="1245" >20:45</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >5</td><td class="right " data-stat="fg_pct" >.400</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >3</td><td class="right " data-stat="fg3_pct" >.333</td><td class="right " data-stat="ft" >5</td><td class="right " data-stat="fta" >5</td><td class="right " data-stat="ft_pct" >1.000</td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >3</td><td class="right " data-stat="trb" >3</td><td class="right " data-stat="ast" >3</td><td class="right " data-stat="stl" >3</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >1</td><td class="right " data-stat="pf" >2</td><td class="right " data-stat="pts" >10</td><td class="right " data-stat="plus_minus" >+5</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="ginobma01" data-stat="player" csk="Ginóbili,Manu" ><a href="/players/g/ginobma01.html">Manu Ginóbili</a></th><td class="right " data-stat="mp" csk="1245" >20:45</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >5</td><td class="right " data-stat="fg_pct" >.400</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >3</td><td class="right " data-stat="fg3_pct" >.333</td><td class="right " data-stat="ft" >5</td><td class="right " data-stat="fta" >5</td><td class="right " data-stat="ft_pct" >1.000</td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >3</td><td class="right " data-stat="trb" >3</td><td class="right " data-stat="ast" >3</td><td class="right " data-stat="stl" >3</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >1</td><td class="right " data-stat="pf" >2</td><td class="right " data-stat="pts" >10</td><td class="right " data-stat="plus_minus" >+5</td></tr>
 <tr ><th scope="row" class="left " data-append-csv="simmojo02" data-stat="player" csk="Simmons,Jonathon" ><a href="/players/s/simmojo02.html">Jonathon Simmons</a></th><td class="right " data-stat="mp" csk="1126" >18:46</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >2</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >2</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right " data-stat="orb" >1</td><td class="right " data-stat="drb" >2</td><td class="right " data-stat="trb" >3</td><td class="right " data-stat="ast" >3</td><td class="right iz" data-stat="stl" >0</td><td class="right " data-stat="blk" >1</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >+3</td></tr>
 <tr ><th scope="row" class="left " data-append-csv="leeda02" data-stat="player" csk="Lee,David" ><a href="/players/l/leeda02.html">David Lee</a></th><td class="right " data-stat="mp" csk="1102" >18:22</td><td class="right " data-stat="fg" >4</td><td class="right " data-stat="fga" >9</td><td class="right " data-stat="fg_pct" >.444</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right " data-stat="orb" >1</td><td class="right " data-stat="drb" >2</td><td class="right " data-stat="trb" >3</td><td class="right " data-stat="ast" >2</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >2</td><td class="right " data-stat="pf" >3</td><td class="right " data-stat="pts" >8</td><td class="right " data-stat="plus_minus" >-15</td></tr>
 <tr ><th scope="row" class="left " data-append-csv="anderky01" data-stat="player" csk="Anderson,Kyle" ><a href="/players/a/anderky01.html">Kyle Anderson</a></th><td class="right " data-stat="mp" csk="468" >7:48</td><td class="right iz" data-stat="fg" >0</td><td class="right iz" data-stat="fga" >0</td><td class="right iz" data-stat="fg_pct" ></td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >1</td><td class="right " data-stat="pf" >1</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >-10</td></tr>
 <tr ><th scope="row" class="left " data-append-csv="dedmode01" data-stat="player" csk="Dedmon,Dewayne" ><a href="/players/d/dedmode01.html">Dewayne Dedmon</a></th><td class="right " data-stat="mp" csk="343" >5:43</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >1</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >2</td><td class="right " data-stat="trb" >2</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >1</td><td class="right " data-stat="pf" >2</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >-12</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="bertada01" data-stat="player" csk="Bertāns,Dāvis" ><a href="/players/b/bertada01.html">Dāvis Bertāns</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
 <tr ><th scope="row" class="left " data-append-csv="murrade01" data-stat="player" csk="Murray,Dejounte" ><a href="/players/m/murrade01.html">Dejounte Murray</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
-<tr ><th scope="row" class="left " data-append-csv="bertada01" data-stat="player" csk="Bertans,Davis" ><a href="/players/b/bertada01.html">Davis Bertans</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
 
    </tbody>
    <tfoot><tr ><th scope="row" class="left " data-stat="player" >Team Totals</th><td class="right " data-stat="mp" >265</td><td class="right " data-stat="fg" >42</td><td class="right " data-stat="fga" >90</td><td class="right " data-stat="fg_pct" >.467</td><td class="right " data-stat="fg3" >9</td><td class="right " data-stat="fg3a" >27</td><td class="right " data-stat="fg3_pct" >.333</td><td class="right " data-stat="ft" >19</td><td class="right " data-stat="fta" >22</td><td class="right " data-stat="ft_pct" >.864</td><td class="right " data-stat="orb" >9</td><td class="right " data-stat="drb" >38</td><td class="right " data-stat="trb" >47</td><td class="right " data-stat="ast" >27</td><td class="right " data-stat="stl" >5</td><td class="right " data-stat="blk" >6</td><td class="right " data-stat="tov" >12</td><td class="right " data-stat="pf" >21</td><td class="right " data-stat="pts" >112</td><td class="right iz" data-stat="plus_minus" ></td></tr>
@@ -707,16 +800,744 @@ sr_menus_setupMainNav_button_inline();
    </div>
 </div>
 
-<div id="all_box_sas_advanced" class="table_wrapper">
+
+    </div>
+
+</div>
+<div class="section_wrapper toggleable box-SAS box-SAS-q1" id="all_box-SAS-q1-basic">    <div class="section_content" id="div_box-SAS-q1-basic">
+
+<div id="all_box-SAS-q1-basic" class="table_wrapper">
 
 <div class="section_heading">
-  <span class="section_anchor" id="box_sas_advanced_link" data-label=""></span><h2></h2>    <div class="section_heading_text">
+  <span class="section_anchor" id="box-SAS-q1-basic_link" data-label="San Antonio Spurs (27-7)"></span><h2>San Antonio Spurs (27-7)</h2>    <div class="section_heading_text">
       <ul>
       </ul>
     </div>
+
 </div>   <div class="table_outer_container">
-      <div class="overthrow table_container" id="div_box_sas_advanced">
-  <table class="sortable stats_table" id="box_sas_advanced" data-cols-to-freeze=1><caption> Table</caption>
+      <div class="overthrow table_container" id="div_box-SAS-q1-basic">
+  <table class="sortable stats_table" id="box-SAS-q1-basic" data-cols-to-freeze=1><caption>San Antonio Spurs (27-7) Table</caption>
+   <colgroup><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col></colgroup>
+   <thead>
+
+      <tr class="over_header"><th></th>
+         <th aria-label="" data-stat="header_tmp" colspan="20" class=" over_header center" >Basic Box Score Stats</th>
+      </tr>
+
+
+
+      <tr>
+         <th aria-label="Starters" data-stat="player" scope="col" class=" poptip sort_default_asc center" >Starters</th>
+         <th aria-label="Minutes Played" data-stat="mp" scope="col" class=" poptip center" data-tip="Minutes Played" data-over-header="Basic Box Score Stats" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" scope="col" class=" poptip center" data-tip="Field Goals" data-over-header="Basic Box Score Stats" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" scope="col" class=" poptip center" data-tip="Field Goal Attempts" data-over-header="Basic Box Score Stats" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" scope="col" class=" poptip center" data-tip="Field Goal Percentage" data-over-header="Basic Box Score Stats" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" scope="col" class=" poptip center" data-tip="3-Point Field Goals" data-over-header="Basic Box Score Stats" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" scope="col" class=" poptip center" data-tip="3-Point Field Goal Attempts" data-over-header="Basic Box Score Stats" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" scope="col" class=" poptip center" data-tip="3-Point Field Goal Percentage" data-over-header="Basic Box Score Stats" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" scope="col" class=" poptip center" data-tip="Free Throws" data-over-header="Basic Box Score Stats" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" scope="col" class=" poptip center" data-tip="Free Throw Attempts" data-over-header="Basic Box Score Stats" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" scope="col" class=" poptip center" data-tip="Free Throw Percentage" data-over-header="Basic Box Score Stats" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" scope="col" class=" poptip center" data-tip="Offensive Rebounds" data-over-header="Basic Box Score Stats" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" scope="col" class=" poptip center" data-tip="Defensive Rebounds" data-over-header="Basic Box Score Stats" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" scope="col" class=" poptip center" data-tip="Total Rebounds" data-over-header="Basic Box Score Stats" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" scope="col" class=" poptip center" data-tip="Assists" data-over-header="Basic Box Score Stats" >AST</th>
+         <th aria-label="Steals" data-stat="stl" scope="col" class=" poptip center" data-tip="Steals" data-over-header="Basic Box Score Stats" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" scope="col" class=" poptip center" data-tip="Blocks" data-over-header="Basic Box Score Stats" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" scope="col" class=" poptip center" data-tip="Turnovers" data-over-header="Basic Box Score Stats" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" scope="col" class=" poptip center" data-tip="Personal Fouls" data-over-header="Basic Box Score Stats" >PF</th>
+         <th aria-label="Points" data-stat="pts" scope="col" class=" poptip center" data-tip="Points" data-over-header="Basic Box Score Stats" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" scope="col" class=" poptip right" data-tip="Plus/Minus" data-over-header="Basic Box Score Stats" >+/-</th>
+      </tr>
+
+   </thead>
+   <tbody>
+<tr ><th scope="row" class="left " data-append-csv="aldrila01" data-stat="player" csk="Aldridge,LaMarcus" ><a href="/players/a/aldrila01.html">LaMarcus Aldridge</a></th><td class="right " data-stat="mp" csk="597" >9:57</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >3</td><td class="right " data-stat="fg_pct" >.667</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >1.000</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right " data-stat="orb" >2</td><td class="right " data-stat="drb" >4</td><td class="right " data-stat="trb" >6</td><td class="right " data-stat="ast" >2</td><td class="right iz" data-stat="stl" >0</td><td class="right " data-stat="blk" >1</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >5</td><td class="right " data-stat="plus_minus" >+3</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="gasolpa01" data-stat="player" csk="Gasol,Pau" ><a href="/players/g/gasolpa01.html">Pau Gasol</a></th><td class="right " data-stat="mp" csk="356" >5:56</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >3</td><td class="right " data-stat="fg_pct" >.667</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >1.000</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right " data-stat="orb" >1</td><td class="right " data-stat="drb" >3</td><td class="right " data-stat="trb" >4</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >2</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >5</td><td class="right " data-stat="plus_minus" >+6</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="parketo01" data-stat="player" csk="Parker,Tony" ><a href="/players/p/parketo01.html">Tony Parker</a></th><td class="right " data-stat="mp" csk="309" >5:09</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >3</td><td class="right " data-stat="fg_pct" >.667</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >1</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >4</td><td class="right " data-stat="plus_minus" >+4</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="greenda02" data-stat="player" csk="Green,Danny" ><a href="/players/g/greenda02.html">Danny Green</a></th><td class="right " data-stat="mp" csk="356" >5:56</td><td class="right iz" data-stat="fg" >0</td><td class="right iz" data-stat="fga" >0</td><td class="right iz" data-stat="fg_pct" ></td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >+6</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="leonaka01" data-stat="player" csk="Leonard,Kawhi" ><a href="/players/l/leonaka01.html">Kawhi Leonard</a></th><td class="right " data-stat="mp" csk="476" >7:56</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >3</td><td class="right " data-stat="fg_pct" >.333</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >2</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right " data-stat="blk" >1</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >2</td><td class="right " data-stat="plus_minus" >+1</td></tr>
+
+      <tr class="thead">
+         <th aria-label="Reserves" data-stat="player" class=" sort_default_asc center" >Reserves</th>
+         <th aria-label="Minutes Played" data-stat="mp" class=" center" data-tip="Minutes Played" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" class=" center" data-tip="Field Goals" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" class=" center" data-tip="Field Goal Attempts" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" class=" center" data-tip="Field Goal Percentage" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" class=" center" data-tip="3-Point Field Goals" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" class=" center" data-tip="3-Point Field Goal Attempts" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" class=" center" data-tip="3-Point Field Goal Percentage" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" class=" center" data-tip="Free Throws" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" class=" center" data-tip="Free Throw Attempts" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" class=" center" data-tip="Free Throw Percentage" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" class=" center" data-tip="Offensive Rebounds" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" class=" center" data-tip="Defensive Rebounds" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" class=" center" data-tip="Total Rebounds" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" class=" center" data-tip="Assists" >AST</th>
+         <th aria-label="Steals" data-stat="stl" class=" center" data-tip="Steals" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" class=" center" data-tip="Blocks" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" class=" center" data-tip="Turnovers" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" class=" center" data-tip="Personal Fouls" >PF</th>
+         <th aria-label="Points" data-stat="pts" class=" center" data-tip="Points" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" class=" right" data-tip="Plus/Minus" >+/-</th>
+      </tr>
+
+
+<tr ><th scope="row" class="left " data-append-csv="millspa02" data-stat="player" csk="Mills,Patty" ><a href="/players/m/millspa02.html">Patty Mills</a></th><td class="right " data-stat="mp" csk="411" >6:51</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >4</td><td class="right " data-stat="fg_pct" >.250</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >2</td><td class="right " data-stat="plus_minus" >-2</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="ginobma01" data-stat="player" csk="Ginóbili,Manu" ><a href="/players/g/ginobma01.html">Manu Ginóbili</a></th><td class="right " data-stat="mp" csk="364" >6:04</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >2</td><td class="right " data-stat="fg_pct" >.500</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >1.000</td><td class="right " data-stat="ft" >2</td><td class="right " data-stat="fta" >2</td><td class="right " data-stat="ft_pct" >1.000</td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >1</td><td class="right " data-stat="stl" >1</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >1</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >5</td><td class="right " data-stat="plus_minus" >-4</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/s/simmojo02.html'>Jonathon Simmons</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="leeda02" data-stat="player" csk="Lee,David" ><a href="/players/l/leeda02.html">David Lee</a></th><td class="right " data-stat="mp" csk="364" >6:04</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >4</td><td class="right " data-stat="fg_pct" >.500</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right " data-stat="orb" >1</td><td class="right iz" data-stat="drb" >0</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >4</td><td class="right " data-stat="plus_minus" >-4</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="anderky01" data-stat="player" csk="Anderson,Kyle" ><a href="/players/a/anderky01.html">Kyle Anderson</a></th><td class="right " data-stat="mp" csk="244" >4:04</td><td class="right iz" data-stat="fg" >0</td><td class="right iz" data-stat="fga" >0</td><td class="right iz" data-stat="fg_pct" ></td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >1</td><td class="right iz" data-stat="pf" >0</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >+1</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="dedmode01" data-stat="player" csk="Dedmon,Dewayne" ><a href="/players/d/dedmode01.html">Dewayne Dedmon</a></th><td class="right " data-stat="mp" csk="123" >2:03</td><td class="right iz" data-stat="fg" >0</td><td class="right iz" data-stat="fga" >0</td><td class="right iz" data-stat="fg_pct" ></td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >-1</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="bertada01" data-stat="player" csk="Bertāns,Dāvis" ><a href="/players/b/bertada01.html">Dāvis Bertāns</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="murrade01" data-stat="player" csk="Murray,Dejounte" ><a href="/players/m/murrade01.html">Dejounte Murray</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+
+   </tbody>
+   <tfoot><tr ><th scope="row" class="left " data-stat="player" >Team Totals</th><td class="right " data-stat="mp" >265</td><td class="right " data-stat="fg" >42</td><td class="right " data-stat="fga" >90</td><td class="right " data-stat="fg_pct" >.467</td><td class="right " data-stat="fg3" >9</td><td class="right " data-stat="fg3a" >27</td><td class="right " data-stat="fg3_pct" >.333</td><td class="right " data-stat="ft" >19</td><td class="right " data-stat="fta" >22</td><td class="right " data-stat="ft_pct" >.864</td><td class="right " data-stat="orb" >9</td><td class="right " data-stat="drb" >38</td><td class="right " data-stat="trb" >47</td><td class="right " data-stat="ast" >27</td><td class="right " data-stat="stl" >5</td><td class="right " data-stat="blk" >6</td><td class="right " data-stat="tov" >12</td><td class="right " data-stat="pf" >21</td><td class="right " data-stat="pts" >112</td><td class="right iz" data-stat="plus_minus" ></td></tr>
+
+   </tfoot>
+
+</table>
+
+      </div>
+   </div>
+</div>
+
+
+    </div>
+
+</div>
+<div class="section_wrapper toggleable box-SAS box-SAS-q2" id="all_box-SAS-q2-basic">    <div class="section_content" id="div_box-SAS-q2-basic">
+
+<div id="all_box-SAS-q2-basic" class="table_wrapper">
+
+<div class="section_heading">
+  <span class="section_anchor" id="box-SAS-q2-basic_link" data-label="San Antonio Spurs (27-7)"></span><h2>San Antonio Spurs (27-7)</h2>    <div class="section_heading_text">
+      <ul>
+      </ul>
+    </div>
+
+</div>   <div class="table_outer_container">
+      <div class="overthrow table_container" id="div_box-SAS-q2-basic">
+  <table class="sortable stats_table" id="box-SAS-q2-basic" data-cols-to-freeze=1><caption>San Antonio Spurs (27-7) Table</caption>
+   <colgroup><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col></colgroup>
+   <thead>
+
+      <tr class="over_header"><th></th>
+         <th aria-label="" data-stat="header_tmp" colspan="20" class=" over_header center" >Basic Box Score Stats</th>
+      </tr>
+
+
+
+      <tr>
+         <th aria-label="Starters" data-stat="player" scope="col" class=" poptip sort_default_asc center" >Starters</th>
+         <th aria-label="Minutes Played" data-stat="mp" scope="col" class=" poptip center" data-tip="Minutes Played" data-over-header="Basic Box Score Stats" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" scope="col" class=" poptip center" data-tip="Field Goals" data-over-header="Basic Box Score Stats" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" scope="col" class=" poptip center" data-tip="Field Goal Attempts" data-over-header="Basic Box Score Stats" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" scope="col" class=" poptip center" data-tip="Field Goal Percentage" data-over-header="Basic Box Score Stats" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" scope="col" class=" poptip center" data-tip="3-Point Field Goals" data-over-header="Basic Box Score Stats" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" scope="col" class=" poptip center" data-tip="3-Point Field Goal Attempts" data-over-header="Basic Box Score Stats" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" scope="col" class=" poptip center" data-tip="3-Point Field Goal Percentage" data-over-header="Basic Box Score Stats" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" scope="col" class=" poptip center" data-tip="Free Throws" data-over-header="Basic Box Score Stats" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" scope="col" class=" poptip center" data-tip="Free Throw Attempts" data-over-header="Basic Box Score Stats" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" scope="col" class=" poptip center" data-tip="Free Throw Percentage" data-over-header="Basic Box Score Stats" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" scope="col" class=" poptip center" data-tip="Offensive Rebounds" data-over-header="Basic Box Score Stats" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" scope="col" class=" poptip center" data-tip="Defensive Rebounds" data-over-header="Basic Box Score Stats" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" scope="col" class=" poptip center" data-tip="Total Rebounds" data-over-header="Basic Box Score Stats" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" scope="col" class=" poptip center" data-tip="Assists" data-over-header="Basic Box Score Stats" >AST</th>
+         <th aria-label="Steals" data-stat="stl" scope="col" class=" poptip center" data-tip="Steals" data-over-header="Basic Box Score Stats" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" scope="col" class=" poptip center" data-tip="Blocks" data-over-header="Basic Box Score Stats" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" scope="col" class=" poptip center" data-tip="Turnovers" data-over-header="Basic Box Score Stats" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" scope="col" class=" poptip center" data-tip="Personal Fouls" data-over-header="Basic Box Score Stats" >PF</th>
+         <th aria-label="Points" data-stat="pts" scope="col" class=" poptip center" data-tip="Points" data-over-header="Basic Box Score Stats" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" scope="col" class=" poptip right" data-tip="Plus/Minus" data-over-header="Basic Box Score Stats" >+/-</th>
+      </tr>
+
+   </thead>
+   <tbody>
+<tr ><th scope="row" class="left " data-append-csv="aldrila01" data-stat="player" csk="Aldridge,LaMarcus" ><a href="/players/a/aldrila01.html">LaMarcus Aldridge</a></th><td class="right " data-stat="mp" csk="500" >8:20</td><td class="right " data-stat="fg" >3</td><td class="right " data-stat="fga" >3</td><td class="right " data-stat="fg_pct" >1.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >3</td><td class="right " data-stat="trb" >3</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >6</td><td class="right " data-stat="plus_minus" >+11</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="gasolpa01" data-stat="player" csk="Gasol,Pau" ><a href="/players/g/gasolpa01.html">Pau Gasol</a></th><td class="right " data-stat="mp" csk="466" >7:46</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >2</td><td class="right " data-stat="fg_pct" >.500</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >2</td><td class="right " data-stat="trb" >2</td><td class="right iz" data-stat="ast" >0</td><td class="right " data-stat="stl" >1</td><td class="right " data-stat="blk" >1</td><td class="right " data-stat="tov" >1</td><td class="right " data-stat="pf" >2</td><td class="right " data-stat="pts" >2</td><td class="right " data-stat="plus_minus" >+11</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="parketo01" data-stat="player" csk="Parker,Tony" ><a href="/players/p/parketo01.html">Tony Parker</a></th><td class="right " data-stat="mp" csk="449" >7:29</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >5</td><td class="right " data-stat="fg_pct" >.400</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >2</td><td class="right " data-stat="fg3_pct" >.500</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >5</td><td class="right " data-stat="plus_minus" >-4</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="greenda02" data-stat="player" csk="Green,Danny" ><a href="/players/g/greenda02.html">Danny Green</a></th><td class="right " data-stat="mp" csk="226" >3:46</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >2</td><td class="right " data-stat="fg_pct" >.500</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >2</td><td class="right " data-stat="fg3_pct" >.500</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >3</td><td class="right " data-stat="plus_minus" >+4</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="leonaka01" data-stat="player" csk="Leonard,Kawhi" ><a href="/players/l/leonaka01.html">Kawhi Leonard</a></th><td class="right " data-stat="mp" csk="286" >4:46</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >2</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right " data-stat="ft" >3</td><td class="right " data-stat="fta" >3</td><td class="right " data-stat="ft_pct" >1.000</td><td class="right " data-stat="orb" >1</td><td class="right iz" data-stat="drb" >0</td><td class="right " data-stat="trb" >1</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >3</td><td class="right " data-stat="plus_minus" >+7</td></tr>
+
+      <tr class="thead">
+         <th aria-label="Reserves" data-stat="player" class=" sort_default_asc center" >Reserves</th>
+         <th aria-label="Minutes Played" data-stat="mp" class=" center" data-tip="Minutes Played" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" class=" center" data-tip="Field Goals" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" class=" center" data-tip="Field Goal Attempts" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" class=" center" data-tip="Field Goal Percentage" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" class=" center" data-tip="3-Point Field Goals" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" class=" center" data-tip="3-Point Field Goal Attempts" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" class=" center" data-tip="3-Point Field Goal Percentage" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" class=" center" data-tip="Free Throws" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" class=" center" data-tip="Free Throw Attempts" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" class=" center" data-tip="Free Throw Percentage" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" class=" center" data-tip="Offensive Rebounds" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" class=" center" data-tip="Defensive Rebounds" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" class=" center" data-tip="Total Rebounds" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" class=" center" data-tip="Assists" >AST</th>
+         <th aria-label="Steals" data-stat="stl" class=" center" data-tip="Steals" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" class=" center" data-tip="Blocks" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" class=" center" data-tip="Turnovers" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" class=" center" data-tip="Personal Fouls" >PF</th>
+         <th aria-label="Points" data-stat="pts" class=" center" data-tip="Points" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" class=" right" data-tip="Plus/Minus" >+/-</th>
+      </tr>
+
+
+<tr ><th scope="row" class="left " data-append-csv="millspa02" data-stat="player" csk="Mills,Patty" ><a href="/players/m/millspa02.html">Patty Mills</a></th><td class="right " data-stat="mp" csk="271" >4:31</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >1</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >+4</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="ginobma01" data-stat="player" csk="Ginóbili,Manu" ><a href="/players/g/ginobma01.html">Manu Ginóbili</a></th><td class="right " data-stat="mp" csk="365" >6:05</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >1</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >+7</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="simmojo02" data-stat="player" csk="Simmons,Jonathon" ><a href="/players/s/simmojo02.html">Jonathon Simmons</a></th><td class="right " data-stat="mp" csk="343" >5:43</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >1</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right " data-stat="orb" >1</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >2</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >-7</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="leeda02" data-stat="player" csk="Lee,David" ><a href="/players/l/leeda02.html">David Lee</a></th><td class="right " data-stat="mp" csk="254" >4:14</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >2</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >2</td><td class="right iz" data-stat="pf" >0</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >-11</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="anderky01" data-stat="player" csk="Anderson,Kyle" ><a href="/players/a/anderky01.html">Kyle Anderson</a></th><td class="right " data-stat="mp" csk="220" >3:40</td><td class="right iz" data-stat="fg" >0</td><td class="right iz" data-stat="fga" >0</td><td class="right iz" data-stat="fg_pct" ></td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >-11</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="dedmode01" data-stat="player" csk="Dedmon,Dewayne" ><a href="/players/d/dedmode01.html">Dewayne Dedmon</a></th><td class="right " data-stat="mp" csk="220" >3:40</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >1</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >1</td><td class="right " data-stat="pf" >2</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >-11</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="bertada01" data-stat="player" csk="Bertāns,Dāvis" ><a href="/players/b/bertada01.html">Dāvis Bertāns</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="murrade01" data-stat="player" csk="Murray,Dejounte" ><a href="/players/m/murrade01.html">Dejounte Murray</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+
+   </tbody>
+   <tfoot><tr ><th scope="row" class="left " data-stat="player" >Team Totals</th><td class="right " data-stat="mp" >265</td><td class="right " data-stat="fg" >42</td><td class="right " data-stat="fga" >90</td><td class="right " data-stat="fg_pct" >.467</td><td class="right " data-stat="fg3" >9</td><td class="right " data-stat="fg3a" >27</td><td class="right " data-stat="fg3_pct" >.333</td><td class="right " data-stat="ft" >19</td><td class="right " data-stat="fta" >22</td><td class="right " data-stat="ft_pct" >.864</td><td class="right " data-stat="orb" >9</td><td class="right " data-stat="drb" >38</td><td class="right " data-stat="trb" >47</td><td class="right " data-stat="ast" >27</td><td class="right " data-stat="stl" >5</td><td class="right " data-stat="blk" >6</td><td class="right " data-stat="tov" >12</td><td class="right " data-stat="pf" >21</td><td class="right " data-stat="pts" >112</td><td class="right iz" data-stat="plus_minus" ></td></tr>
+
+   </tfoot>
+
+</table>
+
+      </div>
+   </div>
+</div>
+
+
+    </div>
+
+</div>
+<div class="section_wrapper toggleable box-SAS box-SAS-h1" id="all_box-SAS-h1-basic">    <div class="section_content" id="div_box-SAS-h1-basic">
+
+<div id="all_box-SAS-h1-basic" class="table_wrapper">
+
+<div class="section_heading">
+  <span class="section_anchor" id="box-SAS-h1-basic_link" data-label="San Antonio Spurs (27-7)"></span><h2>San Antonio Spurs (27-7)</h2>    <div class="section_heading_text">
+      <ul>
+      </ul>
+    </div>
+
+</div>   <div class="table_outer_container">
+      <div class="overthrow table_container" id="div_box-SAS-h1-basic">
+  <table class="sortable stats_table" id="box-SAS-h1-basic" data-cols-to-freeze=1><caption>San Antonio Spurs (27-7) Table</caption>
+   <colgroup><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col></colgroup>
+   <thead>
+
+      <tr class="over_header"><th></th>
+         <th aria-label="" data-stat="header_tmp" colspan="20" class=" over_header center" >Basic Box Score Stats</th>
+      </tr>
+
+
+
+      <tr>
+         <th aria-label="Starters" data-stat="player" scope="col" class=" poptip sort_default_asc center" >Starters</th>
+         <th aria-label="Minutes Played" data-stat="mp" scope="col" class=" poptip center" data-tip="Minutes Played" data-over-header="Basic Box Score Stats" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" scope="col" class=" poptip center" data-tip="Field Goals" data-over-header="Basic Box Score Stats" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" scope="col" class=" poptip center" data-tip="Field Goal Attempts" data-over-header="Basic Box Score Stats" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" scope="col" class=" poptip center" data-tip="Field Goal Percentage" data-over-header="Basic Box Score Stats" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" scope="col" class=" poptip center" data-tip="3-Point Field Goals" data-over-header="Basic Box Score Stats" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" scope="col" class=" poptip center" data-tip="3-Point Field Goal Attempts" data-over-header="Basic Box Score Stats" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" scope="col" class=" poptip center" data-tip="3-Point Field Goal Percentage" data-over-header="Basic Box Score Stats" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" scope="col" class=" poptip center" data-tip="Free Throws" data-over-header="Basic Box Score Stats" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" scope="col" class=" poptip center" data-tip="Free Throw Attempts" data-over-header="Basic Box Score Stats" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" scope="col" class=" poptip center" data-tip="Free Throw Percentage" data-over-header="Basic Box Score Stats" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" scope="col" class=" poptip center" data-tip="Offensive Rebounds" data-over-header="Basic Box Score Stats" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" scope="col" class=" poptip center" data-tip="Defensive Rebounds" data-over-header="Basic Box Score Stats" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" scope="col" class=" poptip center" data-tip="Total Rebounds" data-over-header="Basic Box Score Stats" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" scope="col" class=" poptip center" data-tip="Assists" data-over-header="Basic Box Score Stats" >AST</th>
+         <th aria-label="Steals" data-stat="stl" scope="col" class=" poptip center" data-tip="Steals" data-over-header="Basic Box Score Stats" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" scope="col" class=" poptip center" data-tip="Blocks" data-over-header="Basic Box Score Stats" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" scope="col" class=" poptip center" data-tip="Turnovers" data-over-header="Basic Box Score Stats" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" scope="col" class=" poptip center" data-tip="Personal Fouls" data-over-header="Basic Box Score Stats" >PF</th>
+         <th aria-label="Points" data-stat="pts" scope="col" class=" poptip center" data-tip="Points" data-over-header="Basic Box Score Stats" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" scope="col" class=" poptip right" data-tip="Plus/Minus" data-over-header="Basic Box Score Stats" >+/-</th>
+      </tr>
+
+   </thead>
+   <tbody>
+<tr ><th scope="row" class="left " data-append-csv="aldrila01" data-stat="player" csk="Aldridge,LaMarcus" ><a href="/players/a/aldrila01.html">LaMarcus Aldridge</a></th><td class="right " data-stat="mp" csk="1097" >18:17</td><td class="right " data-stat="fg" >5</td><td class="right " data-stat="fga" >6</td><td class="right " data-stat="fg_pct" >.833</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >1.000</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right " data-stat="orb" >2</td><td class="right " data-stat="drb" >7</td><td class="right " data-stat="trb" >9</td><td class="right " data-stat="ast" >2</td><td class="right iz" data-stat="stl" >0</td><td class="right " data-stat="blk" >1</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >11</td><td class="right " data-stat="plus_minus" >+14</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="gasolpa01" data-stat="player" csk="Gasol,Pau" ><a href="/players/g/gasolpa01.html">Pau Gasol</a></th><td class="right " data-stat="mp" csk="822" >13:42</td><td class="right " data-stat="fg" >3</td><td class="right " data-stat="fga" >5</td><td class="right " data-stat="fg_pct" >.600</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >1.000</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right " data-stat="orb" >1</td><td class="right " data-stat="drb" >5</td><td class="right " data-stat="trb" >6</td><td class="right iz" data-stat="ast" >0</td><td class="right " data-stat="stl" >1</td><td class="right " data-stat="blk" >1</td><td class="right " data-stat="tov" >3</td><td class="right " data-stat="pf" >3</td><td class="right " data-stat="pts" >7</td><td class="right " data-stat="plus_minus" >+17</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="parketo01" data-stat="player" csk="Parker,Tony" ><a href="/players/p/parketo01.html">Tony Parker</a></th><td class="right " data-stat="mp" csk="758" >12:38</td><td class="right " data-stat="fg" >4</td><td class="right " data-stat="fga" >8</td><td class="right " data-stat="fg_pct" >.500</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >2</td><td class="right " data-stat="fg3_pct" >.500</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >1</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >9</td><td class="right iz" data-stat="plus_minus" >0</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="greenda02" data-stat="player" csk="Green,Danny" ><a href="/players/g/greenda02.html">Danny Green</a></th><td class="right " data-stat="mp" csk="582" >9:42</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >2</td><td class="right " data-stat="fg_pct" >.500</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >2</td><td class="right " data-stat="fg3_pct" >.500</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >2</td><td class="right " data-stat="trb" >2</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >2</td><td class="right " data-stat="pts" >3</td><td class="right " data-stat="plus_minus" >+10</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="leonaka01" data-stat="player" csk="Leonard,Kawhi" ><a href="/players/l/leonaka01.html">Kawhi Leonard</a></th><td class="right " data-stat="mp" csk="762" >12:42</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >5</td><td class="right " data-stat="fg_pct" >.200</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >3</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right " data-stat="ft" >3</td><td class="right " data-stat="fta" >3</td><td class="right " data-stat="ft_pct" >1.000</td><td class="right " data-stat="orb" >1</td><td class="right iz" data-stat="drb" >0</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right " data-stat="blk" >1</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >5</td><td class="right " data-stat="plus_minus" >+8</td></tr>
+
+      <tr class="thead">
+         <th aria-label="Reserves" data-stat="player" class=" sort_default_asc center" >Reserves</th>
+         <th aria-label="Minutes Played" data-stat="mp" class=" center" data-tip="Minutes Played" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" class=" center" data-tip="Field Goals" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" class=" center" data-tip="Field Goal Attempts" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" class=" center" data-tip="Field Goal Percentage" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" class=" center" data-tip="3-Point Field Goals" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" class=" center" data-tip="3-Point Field Goal Attempts" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" class=" center" data-tip="3-Point Field Goal Percentage" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" class=" center" data-tip="Free Throws" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" class=" center" data-tip="Free Throw Attempts" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" class=" center" data-tip="Free Throw Percentage" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" class=" center" data-tip="Offensive Rebounds" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" class=" center" data-tip="Defensive Rebounds" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" class=" center" data-tip="Total Rebounds" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" class=" center" data-tip="Assists" >AST</th>
+         <th aria-label="Steals" data-stat="stl" class=" center" data-tip="Steals" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" class=" center" data-tip="Blocks" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" class=" center" data-tip="Turnovers" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" class=" center" data-tip="Personal Fouls" >PF</th>
+         <th aria-label="Points" data-stat="pts" class=" center" data-tip="Points" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" class=" right" data-tip="Plus/Minus" >+/-</th>
+      </tr>
+
+
+<tr ><th scope="row" class="left " data-append-csv="millspa02" data-stat="player" csk="Mills,Patty" ><a href="/players/m/millspa02.html">Patty Mills</a></th><td class="right " data-stat="mp" csk="682" >11:22</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >5</td><td class="right " data-stat="fg_pct" >.200</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right " data-stat="ast" >2</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >2</td><td class="right " data-stat="plus_minus" >+2</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="ginobma01" data-stat="player" csk="Ginóbili,Manu" ><a href="/players/g/ginobma01.html">Manu Ginóbili</a></th><td class="right " data-stat="mp" csk="729" >12:09</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >3</td><td class="right " data-stat="fg_pct" >.333</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >2</td><td class="right " data-stat="fg3_pct" >.500</td><td class="right " data-stat="ft" >2</td><td class="right " data-stat="fta" >2</td><td class="right " data-stat="ft_pct" >1.000</td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >2</td><td class="right " data-stat="stl" >1</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >1</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >5</td><td class="right " data-stat="plus_minus" >+3</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="simmojo02" data-stat="player" csk="Simmons,Jonathon" ><a href="/players/s/simmojo02.html">Jonathon Simmons</a></th><td class="right " data-stat="mp" csk="343" >5:43</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >1</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right " data-stat="orb" >1</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >2</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >-7</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="leeda02" data-stat="player" csk="Lee,David" ><a href="/players/l/leeda02.html">David Lee</a></th><td class="right " data-stat="mp" csk="618" >10:18</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >6</td><td class="right " data-stat="fg_pct" >.333</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right " data-stat="orb" >1</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >2</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >2</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >4</td><td class="right " data-stat="plus_minus" >-15</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="anderky01" data-stat="player" csk="Anderson,Kyle" ><a href="/players/a/anderky01.html">Kyle Anderson</a></th><td class="right " data-stat="mp" csk="464" >7:44</td><td class="right iz" data-stat="fg" >0</td><td class="right iz" data-stat="fga" >0</td><td class="right iz" data-stat="fg_pct" ></td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >1</td><td class="right " data-stat="pf" >1</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >-10</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="dedmode01" data-stat="player" csk="Dedmon,Dewayne" ><a href="/players/d/dedmode01.html">Dewayne Dedmon</a></th><td class="right " data-stat="mp" csk="343" >5:43</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >1</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >2</td><td class="right " data-stat="trb" >2</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >1</td><td class="right " data-stat="pf" >2</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >-12</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="bertada01" data-stat="player" csk="Bertāns,Dāvis" ><a href="/players/b/bertada01.html">Dāvis Bertāns</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="murrade01" data-stat="player" csk="Murray,Dejounte" ><a href="/players/m/murrade01.html">Dejounte Murray</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+
+   </tbody>
+   <tfoot><tr ><th scope="row" class="left " data-stat="player" >Team Totals</th><td class="right " data-stat="mp" >265</td><td class="right " data-stat="fg" >42</td><td class="right " data-stat="fga" >90</td><td class="right " data-stat="fg_pct" >.467</td><td class="right " data-stat="fg3" >9</td><td class="right " data-stat="fg3a" >27</td><td class="right " data-stat="fg3_pct" >.333</td><td class="right " data-stat="ft" >19</td><td class="right " data-stat="fta" >22</td><td class="right " data-stat="ft_pct" >.864</td><td class="right " data-stat="orb" >9</td><td class="right " data-stat="drb" >38</td><td class="right " data-stat="trb" >47</td><td class="right " data-stat="ast" >27</td><td class="right " data-stat="stl" >5</td><td class="right " data-stat="blk" >6</td><td class="right " data-stat="tov" >12</td><td class="right " data-stat="pf" >21</td><td class="right " data-stat="pts" >112</td><td class="right iz" data-stat="plus_minus" ></td></tr>
+
+   </tfoot>
+
+</table>
+
+      </div>
+   </div>
+</div>
+
+
+    </div>
+
+</div>
+<div class="section_wrapper toggleable box-SAS box-SAS-q3" id="all_box-SAS-q3-basic">    <div class="section_content" id="div_box-SAS-q3-basic">
+
+<div id="all_box-SAS-q3-basic" class="table_wrapper">
+
+<div class="section_heading">
+  <span class="section_anchor" id="box-SAS-q3-basic_link" data-label="San Antonio Spurs (27-7)"></span><h2>San Antonio Spurs (27-7)</h2>    <div class="section_heading_text">
+      <ul>
+      </ul>
+    </div>
+
+</div>   <div class="table_outer_container">
+      <div class="overthrow table_container" id="div_box-SAS-q3-basic">
+  <table class="sortable stats_table" id="box-SAS-q3-basic" data-cols-to-freeze=1><caption>San Antonio Spurs (27-7) Table</caption>
+   <colgroup><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col></colgroup>
+   <thead>
+
+      <tr class="over_header"><th></th>
+         <th aria-label="" data-stat="header_tmp" colspan="20" class=" over_header center" >Basic Box Score Stats</th>
+      </tr>
+
+
+
+      <tr>
+         <th aria-label="Starters" data-stat="player" scope="col" class=" poptip sort_default_asc center" >Starters</th>
+         <th aria-label="Minutes Played" data-stat="mp" scope="col" class=" poptip center" data-tip="Minutes Played" data-over-header="Basic Box Score Stats" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" scope="col" class=" poptip center" data-tip="Field Goals" data-over-header="Basic Box Score Stats" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" scope="col" class=" poptip center" data-tip="Field Goal Attempts" data-over-header="Basic Box Score Stats" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" scope="col" class=" poptip center" data-tip="Field Goal Percentage" data-over-header="Basic Box Score Stats" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" scope="col" class=" poptip center" data-tip="3-Point Field Goals" data-over-header="Basic Box Score Stats" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" scope="col" class=" poptip center" data-tip="3-Point Field Goal Attempts" data-over-header="Basic Box Score Stats" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" scope="col" class=" poptip center" data-tip="3-Point Field Goal Percentage" data-over-header="Basic Box Score Stats" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" scope="col" class=" poptip center" data-tip="Free Throws" data-over-header="Basic Box Score Stats" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" scope="col" class=" poptip center" data-tip="Free Throw Attempts" data-over-header="Basic Box Score Stats" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" scope="col" class=" poptip center" data-tip="Free Throw Percentage" data-over-header="Basic Box Score Stats" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" scope="col" class=" poptip center" data-tip="Offensive Rebounds" data-over-header="Basic Box Score Stats" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" scope="col" class=" poptip center" data-tip="Defensive Rebounds" data-over-header="Basic Box Score Stats" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" scope="col" class=" poptip center" data-tip="Total Rebounds" data-over-header="Basic Box Score Stats" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" scope="col" class=" poptip center" data-tip="Assists" data-over-header="Basic Box Score Stats" >AST</th>
+         <th aria-label="Steals" data-stat="stl" scope="col" class=" poptip center" data-tip="Steals" data-over-header="Basic Box Score Stats" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" scope="col" class=" poptip center" data-tip="Blocks" data-over-header="Basic Box Score Stats" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" scope="col" class=" poptip center" data-tip="Turnovers" data-over-header="Basic Box Score Stats" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" scope="col" class=" poptip center" data-tip="Personal Fouls" data-over-header="Basic Box Score Stats" >PF</th>
+         <th aria-label="Points" data-stat="pts" scope="col" class=" poptip center" data-tip="Points" data-over-header="Basic Box Score Stats" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" scope="col" class=" poptip right" data-tip="Plus/Minus" data-over-header="Basic Box Score Stats" >+/-</th>
+      </tr>
+
+   </thead>
+   <tbody>
+<tr ><th scope="row" class="left " data-append-csv="aldrila01" data-stat="player" csk="Aldridge,LaMarcus" ><a href="/players/a/aldrila01.html">LaMarcus Aldridge</a></th><td class="right " data-stat="mp" csk="599" >9:59</td><td class="right " data-stat="fg" >3</td><td class="right " data-stat="fga" >5</td><td class="right " data-stat="fg_pct" >.600</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right " data-stat="orb" >1</td><td class="right " data-stat="drb" >3</td><td class="right " data-stat="trb" >4</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right " data-stat="blk" >2</td><td class="right " data-stat="tov" >1</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >6</td><td class="right " data-stat="plus_minus" >+6</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="gasolpa01" data-stat="player" csk="Gasol,Pau" ><a href="/players/g/gasolpa01.html">Pau Gasol</a></th><td class="right " data-stat="mp" csk="466" >7:46</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >2</td><td class="right " data-stat="fg_pct" >.500</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right " data-stat="ft" >4</td><td class="right " data-stat="fta" >4</td><td class="right " data-stat="ft_pct" >1.000</td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >6</td><td class="right " data-stat="plus_minus" >-5</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="parketo01" data-stat="player" csk="Parker,Tony" ><a href="/players/p/parketo01.html">Tony Parker</a></th><td class="right " data-stat="mp" csk="378" >6:18</td><td class="right " data-stat="fg" >3</td><td class="right " data-stat="fga" >3</td><td class="right " data-stat="fg_pct" >1.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right " data-stat="ft" >1</td><td class="right " data-stat="fta" >2</td><td class="right " data-stat="ft_pct" >.500</td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >2</td><td class="right " data-stat="trb" >2</td><td class="right " data-stat="ast" >3</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >7</td><td class="right " data-stat="plus_minus" >+1</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="greenda02" data-stat="player" csk="Green,Danny" ><a href="/players/g/greenda02.html">Danny Green</a></th><td class="right " data-stat="mp" csk="345" >5:45</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >3</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >3</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >-2</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="leonaka01" data-stat="player" csk="Leonard,Kawhi" ><a href="/players/l/leonaka01.html">Kawhi Leonard</a></th><td class="right " data-stat="mp" csk="366" >6:06</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >1</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right iz" data-stat="ast" >0</td><td class="right " data-stat="stl" >1</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >1</td><td class="right " data-stat="pf" >2</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >-5</td></tr>
+
+      <tr class="thead">
+         <th aria-label="Reserves" data-stat="player" class=" sort_default_asc center" >Reserves</th>
+         <th aria-label="Minutes Played" data-stat="mp" class=" center" data-tip="Minutes Played" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" class=" center" data-tip="Field Goals" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" class=" center" data-tip="Field Goal Attempts" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" class=" center" data-tip="Field Goal Percentage" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" class=" center" data-tip="3-Point Field Goals" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" class=" center" data-tip="3-Point Field Goal Attempts" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" class=" center" data-tip="3-Point Field Goal Percentage" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" class=" center" data-tip="Free Throws" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" class=" center" data-tip="Free Throw Attempts" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" class=" center" data-tip="Free Throw Percentage" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" class=" center" data-tip="Offensive Rebounds" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" class=" center" data-tip="Defensive Rebounds" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" class=" center" data-tip="Total Rebounds" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" class=" center" data-tip="Assists" >AST</th>
+         <th aria-label="Steals" data-stat="stl" class=" center" data-tip="Steals" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" class=" center" data-tip="Blocks" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" class=" center" data-tip="Turnovers" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" class=" center" data-tip="Personal Fouls" >PF</th>
+         <th aria-label="Points" data-stat="pts" class=" center" data-tip="Points" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" class=" right" data-tip="Plus/Minus" >+/-</th>
+      </tr>
+
+
+<tr ><th scope="row" class="left " data-append-csv="millspa02" data-stat="player" csk="Mills,Patty" ><a href="/players/m/millspa02.html">Patty Mills</a></th><td class="right " data-stat="mp" csk="342" >5:42</td><td class="right iz" data-stat="fg" >0</td><td class="right iz" data-stat="fga" >0</td><td class="right iz" data-stat="fg_pct" ></td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >+2</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="ginobma01" data-stat="player" csk="Ginóbili,Manu" ><a href="/players/g/ginobma01.html">Manu Ginóbili</a></th><td class="right " data-stat="mp" csk="375" >6:15</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >2</td><td class="right " data-stat="fg_pct" >.500</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right " data-stat="ft" >3</td><td class="right " data-stat="fta" >3</td><td class="right " data-stat="ft_pct" >1.000</td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >1</td><td class="right " data-stat="stl" >1</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >2</td><td class="right " data-stat="pts" >5</td><td class="right " data-stat="plus_minus" >+5</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="simmojo02" data-stat="player" csk="Simmons,Jonathon" ><a href="/players/s/simmojo02.html">Jonathon Simmons</a></th><td class="right " data-stat="mp" csk="354" >5:54</td><td class="right iz" data-stat="fg" >0</td><td class="right iz" data-stat="fga" >0</td><td class="right iz" data-stat="fg_pct" ></td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >+8</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="leeda02" data-stat="player" csk="Lee,David" ><a href="/players/l/leeda02.html">David Lee</a></th><td class="right " data-stat="mp" csk="375" >6:15</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >3</td><td class="right " data-stat="fg_pct" >.667</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >1</td><td class="right " data-stat="stl" >1</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >4</td><td class="right " data-stat="plus_minus" >+5</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/a/anderky01.html'>Kyle Anderson</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/d/dedmode01.html'>Dewayne Dedmon</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="bertada01" data-stat="player" csk="Bertāns,Dāvis" ><a href="/players/b/bertada01.html">Dāvis Bertāns</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="murrade01" data-stat="player" csk="Murray,Dejounte" ><a href="/players/m/murrade01.html">Dejounte Murray</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+
+   </tbody>
+   <tfoot><tr ><th scope="row" class="left " data-stat="player" >Team Totals</th><td class="right " data-stat="mp" >265</td><td class="right " data-stat="fg" >42</td><td class="right " data-stat="fga" >90</td><td class="right " data-stat="fg_pct" >.467</td><td class="right " data-stat="fg3" >9</td><td class="right " data-stat="fg3a" >27</td><td class="right " data-stat="fg3_pct" >.333</td><td class="right " data-stat="ft" >19</td><td class="right " data-stat="fta" >22</td><td class="right " data-stat="ft_pct" >.864</td><td class="right " data-stat="orb" >9</td><td class="right " data-stat="drb" >38</td><td class="right " data-stat="trb" >47</td><td class="right " data-stat="ast" >27</td><td class="right " data-stat="stl" >5</td><td class="right " data-stat="blk" >6</td><td class="right " data-stat="tov" >12</td><td class="right " data-stat="pf" >21</td><td class="right " data-stat="pts" >112</td><td class="right iz" data-stat="plus_minus" ></td></tr>
+
+   </tfoot>
+
+</table>
+
+      </div>
+   </div>
+</div>
+
+
+    </div>
+
+</div>
+<div class="section_wrapper toggleable box-SAS box-SAS-q4" id="all_box-SAS-q4-basic">    <div class="section_content" id="div_box-SAS-q4-basic">
+
+<div id="all_box-SAS-q4-basic" class="table_wrapper">
+
+<div class="section_heading">
+  <span class="section_anchor" id="box-SAS-q4-basic_link" data-label="San Antonio Spurs (27-7)"></span><h2>San Antonio Spurs (27-7)</h2>    <div class="section_heading_text">
+      <ul>
+      </ul>
+    </div>
+
+</div>   <div class="table_outer_container">
+      <div class="overthrow table_container" id="div_box-SAS-q4-basic">
+  <table class="sortable stats_table" id="box-SAS-q4-basic" data-cols-to-freeze=1><caption>San Antonio Spurs (27-7) Table</caption>
+   <colgroup><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col></colgroup>
+   <thead>
+
+      <tr class="over_header"><th></th>
+         <th aria-label="" data-stat="header_tmp" colspan="20" class=" over_header center" >Basic Box Score Stats</th>
+      </tr>
+
+
+
+      <tr>
+         <th aria-label="Starters" data-stat="player" scope="col" class=" poptip sort_default_asc center" >Starters</th>
+         <th aria-label="Minutes Played" data-stat="mp" scope="col" class=" poptip center" data-tip="Minutes Played" data-over-header="Basic Box Score Stats" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" scope="col" class=" poptip center" data-tip="Field Goals" data-over-header="Basic Box Score Stats" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" scope="col" class=" poptip center" data-tip="Field Goal Attempts" data-over-header="Basic Box Score Stats" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" scope="col" class=" poptip center" data-tip="Field Goal Percentage" data-over-header="Basic Box Score Stats" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" scope="col" class=" poptip center" data-tip="3-Point Field Goals" data-over-header="Basic Box Score Stats" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" scope="col" class=" poptip center" data-tip="3-Point Field Goal Attempts" data-over-header="Basic Box Score Stats" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" scope="col" class=" poptip center" data-tip="3-Point Field Goal Percentage" data-over-header="Basic Box Score Stats" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" scope="col" class=" poptip center" data-tip="Free Throws" data-over-header="Basic Box Score Stats" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" scope="col" class=" poptip center" data-tip="Free Throw Attempts" data-over-header="Basic Box Score Stats" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" scope="col" class=" poptip center" data-tip="Free Throw Percentage" data-over-header="Basic Box Score Stats" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" scope="col" class=" poptip center" data-tip="Offensive Rebounds" data-over-header="Basic Box Score Stats" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" scope="col" class=" poptip center" data-tip="Defensive Rebounds" data-over-header="Basic Box Score Stats" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" scope="col" class=" poptip center" data-tip="Total Rebounds" data-over-header="Basic Box Score Stats" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" scope="col" class=" poptip center" data-tip="Assists" data-over-header="Basic Box Score Stats" >AST</th>
+         <th aria-label="Steals" data-stat="stl" scope="col" class=" poptip center" data-tip="Steals" data-over-header="Basic Box Score Stats" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" scope="col" class=" poptip center" data-tip="Blocks" data-over-header="Basic Box Score Stats" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" scope="col" class=" poptip center" data-tip="Turnovers" data-over-header="Basic Box Score Stats" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" scope="col" class=" poptip center" data-tip="Personal Fouls" data-over-header="Basic Box Score Stats" >PF</th>
+         <th aria-label="Points" data-stat="pts" scope="col" class=" poptip center" data-tip="Points" data-over-header="Basic Box Score Stats" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" scope="col" class=" poptip right" data-tip="Plus/Minus" data-over-header="Basic Box Score Stats" >+/-</th>
+      </tr>
+
+   </thead>
+   <tbody>
+<tr ><th scope="row" class="left " data-append-csv="aldrila01" data-stat="player" csk="Aldridge,LaMarcus" ><a href="/players/a/aldrila01.html">LaMarcus Aldridge</a></th><td class="right " data-stat="mp" csk="611" >10:11</td><td class="right " data-stat="fg" >3</td><td class="right " data-stat="fga" >3</td><td class="right " data-stat="fg_pct" >1.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >1</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >6</td><td class="right iz" data-stat="plus_minus" >0</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="gasolpa01" data-stat="player" csk="Gasol,Pau" ><a href="/players/g/gasolpa01.html">Pau Gasol</a></th><td class="right " data-stat="mp" csk="709" >11:49</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >2</td><td class="right " data-stat="fg_pct" >.500</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >2</td><td class="right " data-stat="plus_minus" >-4</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="parketo01" data-stat="player" csk="Parker,Tony" ><a href="/players/p/parketo01.html">Tony Parker</a></th><td class="right " data-stat="mp" csk="463" >7:43</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >4</td><td class="right " data-stat="fg_pct" >.500</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right " data-stat="orb" >1</td><td class="right iz" data-stat="drb" >0</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >2</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >4</td><td class="right " data-stat="plus_minus" >+5</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="greenda02" data-stat="player" csk="Green,Danny" ><a href="/players/g/greenda02.html">Danny Green</a></th><td class="right " data-stat="mp" csk="720" >12:00</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >3</td><td class="right " data-stat="fg_pct" >.667</td><td class="right " data-stat="fg3" >2</td><td class="right " data-stat="fg3a" >3</td><td class="right " data-stat="fg3_pct" >.667</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >3</td><td class="right " data-stat="trb" >3</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >6</td><td class="right " data-stat="plus_minus" >-5</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="leonaka01" data-stat="player" csk="Leonard,Kawhi" ><a href="/players/l/leonaka01.html">Kawhi Leonard</a></th><td class="right " data-stat="mp" csk="261" >4:21</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >4</td><td class="right " data-stat="fg_pct" >.250</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >2</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right " data-stat="ft" >3</td><td class="right " data-stat="fta" >4</td><td class="right " data-stat="ft_pct" >.750</td><td class="right " data-stat="orb" >1</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >2</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >5</td><td class="right " data-stat="plus_minus" >-8</td></tr>
+
+      <tr class="thead">
+         <th aria-label="Reserves" data-stat="player" class=" sort_default_asc center" >Reserves</th>
+         <th aria-label="Minutes Played" data-stat="mp" class=" center" data-tip="Minutes Played" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" class=" center" data-tip="Field Goals" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" class=" center" data-tip="Field Goal Attempts" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" class=" center" data-tip="Field Goal Percentage" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" class=" center" data-tip="3-Point Field Goals" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" class=" center" data-tip="3-Point Field Goal Attempts" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" class=" center" data-tip="3-Point Field Goal Percentage" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" class=" center" data-tip="Free Throws" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" class=" center" data-tip="Free Throw Attempts" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" class=" center" data-tip="Free Throw Percentage" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" class=" center" data-tip="Offensive Rebounds" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" class=" center" data-tip="Defensive Rebounds" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" class=" center" data-tip="Total Rebounds" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" class=" center" data-tip="Assists" >AST</th>
+         <th aria-label="Steals" data-stat="stl" class=" center" data-tip="Steals" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" class=" center" data-tip="Blocks" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" class=" center" data-tip="Turnovers" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" class=" center" data-tip="Personal Fouls" >PF</th>
+         <th aria-label="Points" data-stat="pts" class=" center" data-tip="Points" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" class=" right" data-tip="Plus/Minus" >+/-</th>
+      </tr>
+
+
+<tr ><th scope="row" class="left " data-append-csv="millspa02" data-stat="player" csk="Mills,Patty" ><a href="/players/m/millspa02.html">Patty Mills</a></th><td class="right " data-stat="mp" csk="250" >4:10</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >3</td><td class="right " data-stat="fg_pct" >.333</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >3</td><td class="right " data-stat="fg3_pct" >.333</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >3</td><td class="right " data-stat="plus_minus" >-7</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="ginobma01" data-stat="player" csk="Ginóbili,Manu" ><a href="/players/g/ginobma01.html">Manu Ginóbili</a></th><td class="right " data-stat="mp" csk="68" >1:08</td><td class="right iz" data-stat="fg" >0</td><td class="right iz" data-stat="fga" >0</td><td class="right iz" data-stat="fg_pct" ></td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >-3</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="simmojo02" data-stat="player" csk="Simmons,Jonathon" ><a href="/players/s/simmojo02.html">Jonathon Simmons</a></th><td class="right " data-stat="mp" csk="409" >6:49</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >1</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >2</td><td class="right iz" data-stat="stl" >0</td><td class="right " data-stat="blk" >1</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >+2</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="leeda02" data-stat="player" csk="Lee,David" ><a href="/players/l/leeda02.html">David Lee</a></th><td class="right " data-stat="mp" csk="109" >1:49</td><td class="right iz" data-stat="fg" >0</td><td class="right iz" data-stat="fga" >0</td><td class="right iz" data-stat="fg_pct" ></td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >2</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >-5</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/a/anderky01.html'>Kyle Anderson</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/d/dedmode01.html'>Dewayne Dedmon</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="bertada01" data-stat="player" csk="Bertāns,Dāvis" ><a href="/players/b/bertada01.html">Dāvis Bertāns</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="murrade01" data-stat="player" csk="Murray,Dejounte" ><a href="/players/m/murrade01.html">Dejounte Murray</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+
+   </tbody>
+   <tfoot><tr ><th scope="row" class="left " data-stat="player" >Team Totals</th><td class="right " data-stat="mp" >265</td><td class="right " data-stat="fg" >42</td><td class="right " data-stat="fga" >90</td><td class="right " data-stat="fg_pct" >.467</td><td class="right " data-stat="fg3" >9</td><td class="right " data-stat="fg3a" >27</td><td class="right " data-stat="fg3_pct" >.333</td><td class="right " data-stat="ft" >19</td><td class="right " data-stat="fta" >22</td><td class="right " data-stat="ft_pct" >.864</td><td class="right " data-stat="orb" >9</td><td class="right " data-stat="drb" >38</td><td class="right " data-stat="trb" >47</td><td class="right " data-stat="ast" >27</td><td class="right " data-stat="stl" >5</td><td class="right " data-stat="blk" >6</td><td class="right " data-stat="tov" >12</td><td class="right " data-stat="pf" >21</td><td class="right " data-stat="pts" >112</td><td class="right iz" data-stat="plus_minus" ></td></tr>
+
+   </tfoot>
+
+</table>
+
+      </div>
+   </div>
+</div>
+
+
+    </div>
+
+</div>
+<div class="section_wrapper toggleable box-SAS box-SAS-h2" id="all_box-SAS-h2-basic">    <div class="section_content" id="div_box-SAS-h2-basic">
+
+<div id="all_box-SAS-h2-basic" class="table_wrapper">
+
+<div class="section_heading">
+  <span class="section_anchor" id="box-SAS-h2-basic_link" data-label="San Antonio Spurs (27-7)"></span><h2>San Antonio Spurs (27-7)</h2>    <div class="section_heading_text">
+      <ul>
+      </ul>
+    </div>
+
+</div>   <div class="table_outer_container">
+      <div class="overthrow table_container" id="div_box-SAS-h2-basic">
+  <table class="sortable stats_table" id="box-SAS-h2-basic" data-cols-to-freeze=1><caption>San Antonio Spurs (27-7) Table</caption>
+   <colgroup><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col></colgroup>
+   <thead>
+
+      <tr class="over_header"><th></th>
+         <th aria-label="" data-stat="header_tmp" colspan="20" class=" over_header center" >Basic Box Score Stats</th>
+      </tr>
+
+
+
+      <tr>
+         <th aria-label="Starters" data-stat="player" scope="col" class=" poptip sort_default_asc center" >Starters</th>
+         <th aria-label="Minutes Played" data-stat="mp" scope="col" class=" poptip center" data-tip="Minutes Played" data-over-header="Basic Box Score Stats" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" scope="col" class=" poptip center" data-tip="Field Goals" data-over-header="Basic Box Score Stats" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" scope="col" class=" poptip center" data-tip="Field Goal Attempts" data-over-header="Basic Box Score Stats" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" scope="col" class=" poptip center" data-tip="Field Goal Percentage" data-over-header="Basic Box Score Stats" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" scope="col" class=" poptip center" data-tip="3-Point Field Goals" data-over-header="Basic Box Score Stats" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" scope="col" class=" poptip center" data-tip="3-Point Field Goal Attempts" data-over-header="Basic Box Score Stats" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" scope="col" class=" poptip center" data-tip="3-Point Field Goal Percentage" data-over-header="Basic Box Score Stats" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" scope="col" class=" poptip center" data-tip="Free Throws" data-over-header="Basic Box Score Stats" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" scope="col" class=" poptip center" data-tip="Free Throw Attempts" data-over-header="Basic Box Score Stats" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" scope="col" class=" poptip center" data-tip="Free Throw Percentage" data-over-header="Basic Box Score Stats" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" scope="col" class=" poptip center" data-tip="Offensive Rebounds" data-over-header="Basic Box Score Stats" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" scope="col" class=" poptip center" data-tip="Defensive Rebounds" data-over-header="Basic Box Score Stats" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" scope="col" class=" poptip center" data-tip="Total Rebounds" data-over-header="Basic Box Score Stats" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" scope="col" class=" poptip center" data-tip="Assists" data-over-header="Basic Box Score Stats" >AST</th>
+         <th aria-label="Steals" data-stat="stl" scope="col" class=" poptip center" data-tip="Steals" data-over-header="Basic Box Score Stats" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" scope="col" class=" poptip center" data-tip="Blocks" data-over-header="Basic Box Score Stats" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" scope="col" class=" poptip center" data-tip="Turnovers" data-over-header="Basic Box Score Stats" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" scope="col" class=" poptip center" data-tip="Personal Fouls" data-over-header="Basic Box Score Stats" >PF</th>
+         <th aria-label="Points" data-stat="pts" scope="col" class=" poptip center" data-tip="Points" data-over-header="Basic Box Score Stats" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" scope="col" class=" poptip right" data-tip="Plus/Minus" data-over-header="Basic Box Score Stats" >+/-</th>
+      </tr>
+
+   </thead>
+   <tbody>
+<tr ><th scope="row" class="left " data-append-csv="aldrila01" data-stat="player" csk="Aldridge,LaMarcus" ><a href="/players/a/aldrila01.html">LaMarcus Aldridge</a></th><td class="right " data-stat="mp" csk="1210" >20:10</td><td class="right " data-stat="fg" >6</td><td class="right " data-stat="fga" >8</td><td class="right " data-stat="fg_pct" >.750</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right " data-stat="orb" >1</td><td class="right " data-stat="drb" >3</td><td class="right " data-stat="trb" >4</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right " data-stat="blk" >2</td><td class="right " data-stat="tov" >2</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >12</td><td class="right " data-stat="plus_minus" >+6</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="gasolpa01" data-stat="player" csk="Gasol,Pau" ><a href="/players/g/gasolpa01.html">Pau Gasol</a></th><td class="right " data-stat="mp" csk="1175" >19:35</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >4</td><td class="right " data-stat="fg_pct" >.500</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right " data-stat="ft" >4</td><td class="right " data-stat="fta" >4</td><td class="right " data-stat="ft_pct" >1.000</td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >2</td><td class="right " data-stat="trb" >2</td><td class="right " data-stat="ast" >2</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >8</td><td class="right " data-stat="plus_minus" >-9</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="parketo01" data-stat="player" csk="Parker,Tony" ><a href="/players/p/parketo01.html">Tony Parker</a></th><td class="right " data-stat="mp" csk="841" >14:01</td><td class="right " data-stat="fg" >5</td><td class="right " data-stat="fga" >7</td><td class="right " data-stat="fg_pct" >.714</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right " data-stat="ft" >1</td><td class="right " data-stat="fta" >2</td><td class="right " data-stat="ft_pct" >.500</td><td class="right " data-stat="orb" >1</td><td class="right " data-stat="drb" >2</td><td class="right " data-stat="trb" >3</td><td class="right " data-stat="ast" >5</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >11</td><td class="right " data-stat="plus_minus" >+6</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="greenda02" data-stat="player" csk="Green,Danny" ><a href="/players/g/greenda02.html">Danny Green</a></th><td class="right " data-stat="mp" csk="1065" >17:45</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >6</td><td class="right " data-stat="fg_pct" >.333</td><td class="right " data-stat="fg3" >2</td><td class="right " data-stat="fg3a" >6</td><td class="right " data-stat="fg3_pct" >.333</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >3</td><td class="right " data-stat="trb" >3</td><td class="right " data-stat="ast" >2</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >6</td><td class="right " data-stat="plus_minus" >-7</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="leonaka01" data-stat="player" csk="Leonard,Kawhi" ><a href="/players/l/leonaka01.html">Kawhi Leonard</a></th><td class="right " data-stat="mp" csk="627" >10:27</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >5</td><td class="right " data-stat="fg_pct" >.200</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >2</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right " data-stat="ft" >3</td><td class="right " data-stat="fta" >4</td><td class="right " data-stat="ft_pct" >.750</td><td class="right " data-stat="orb" >1</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >2</td><td class="right iz" data-stat="ast" >0</td><td class="right " data-stat="stl" >1</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >1</td><td class="right " data-stat="pf" >2</td><td class="right " data-stat="pts" >5</td><td class="right " data-stat="plus_minus" >-13</td></tr>
+
+      <tr class="thead">
+         <th aria-label="Reserves" data-stat="player" class=" sort_default_asc center" >Reserves</th>
+         <th aria-label="Minutes Played" data-stat="mp" class=" center" data-tip="Minutes Played" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" class=" center" data-tip="Field Goals" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" class=" center" data-tip="Field Goal Attempts" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" class=" center" data-tip="Field Goal Percentage" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" class=" center" data-tip="3-Point Field Goals" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" class=" center" data-tip="3-Point Field Goal Attempts" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" class=" center" data-tip="3-Point Field Goal Percentage" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" class=" center" data-tip="Free Throws" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" class=" center" data-tip="Free Throw Attempts" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" class=" center" data-tip="Free Throw Percentage" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" class=" center" data-tip="Offensive Rebounds" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" class=" center" data-tip="Defensive Rebounds" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" class=" center" data-tip="Total Rebounds" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" class=" center" data-tip="Assists" >AST</th>
+         <th aria-label="Steals" data-stat="stl" class=" center" data-tip="Steals" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" class=" center" data-tip="Blocks" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" class=" center" data-tip="Turnovers" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" class=" center" data-tip="Personal Fouls" >PF</th>
+         <th aria-label="Points" data-stat="pts" class=" center" data-tip="Points" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" class=" right" data-tip="Plus/Minus" >+/-</th>
+      </tr>
+
+
+<tr ><th scope="row" class="left " data-append-csv="millspa02" data-stat="player" csk="Mills,Patty" ><a href="/players/m/millspa02.html">Patty Mills</a></th><td class="right " data-stat="mp" csk="592" >9:52</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >3</td><td class="right " data-stat="fg_pct" >.333</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >3</td><td class="right " data-stat="fg3_pct" >.333</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >3</td><td class="right " data-stat="plus_minus" >-5</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="ginobma01" data-stat="player" csk="Ginóbili,Manu" ><a href="/players/g/ginobma01.html">Manu Ginóbili</a></th><td class="right " data-stat="mp" csk="443" >7:23</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >2</td><td class="right " data-stat="fg_pct" >.500</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right " data-stat="ft" >3</td><td class="right " data-stat="fta" >3</td><td class="right " data-stat="ft_pct" >1.000</td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >1</td><td class="right " data-stat="stl" >1</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >2</td><td class="right " data-stat="pts" >5</td><td class="right " data-stat="plus_minus" >+2</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="simmojo02" data-stat="player" csk="Simmons,Jonathon" ><a href="/players/s/simmojo02.html">Jonathon Simmons</a></th><td class="right " data-stat="mp" csk="763" >12:43</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >1</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >2</td><td class="right iz" data-stat="stl" >0</td><td class="right " data-stat="blk" >1</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >+10</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="leeda02" data-stat="player" csk="Lee,David" ><a href="/players/l/leeda02.html">David Lee</a></th><td class="right " data-stat="mp" csk="484" >8:04</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >3</td><td class="right " data-stat="fg_pct" >.667</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >1</td><td class="right " data-stat="stl" >1</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >3</td><td class="right " data-stat="pts" >4</td><td class="right iz" data-stat="plus_minus" >0</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/a/anderky01.html'>Kyle Anderson</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/d/dedmode01.html'>Dewayne Dedmon</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="bertada01" data-stat="player" csk="Bertāns,Dāvis" ><a href="/players/b/bertada01.html">Dāvis Bertāns</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="murrade01" data-stat="player" csk="Murray,Dejounte" ><a href="/players/m/murrade01.html">Dejounte Murray</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+
+   </tbody>
+   <tfoot><tr ><th scope="row" class="left " data-stat="player" >Team Totals</th><td class="right " data-stat="mp" >265</td><td class="right " data-stat="fg" >42</td><td class="right " data-stat="fga" >90</td><td class="right " data-stat="fg_pct" >.467</td><td class="right " data-stat="fg3" >9</td><td class="right " data-stat="fg3a" >27</td><td class="right " data-stat="fg3_pct" >.333</td><td class="right " data-stat="ft" >19</td><td class="right " data-stat="fta" >22</td><td class="right " data-stat="ft_pct" >.864</td><td class="right " data-stat="orb" >9</td><td class="right " data-stat="drb" >38</td><td class="right " data-stat="trb" >47</td><td class="right " data-stat="ast" >27</td><td class="right " data-stat="stl" >5</td><td class="right " data-stat="blk" >6</td><td class="right " data-stat="tov" >12</td><td class="right " data-stat="pf" >21</td><td class="right " data-stat="pts" >112</td><td class="right iz" data-stat="plus_minus" ></td></tr>
+
+   </tfoot>
+
+</table>
+
+      </div>
+   </div>
+</div>
+
+
+    </div>
+
+</div>
+<div class="section_wrapper toggleable box-SAS box-SAS-q5" id="all_box-SAS-q5-basic">    <div class="section_content" id="div_box-SAS-q5-basic">
+
+<div id="all_box-SAS-q5-basic" class="table_wrapper">
+
+<div class="section_heading">
+  <span class="section_anchor" id="box-SAS-q5-basic_link" data-label="San Antonio Spurs (27-7)"></span><h2>San Antonio Spurs (27-7)</h2>    <div class="section_heading_text">
+      <ul>
+      </ul>
+    </div>
+
+</div>   <div class="table_outer_container">
+      <div class="overthrow table_container" id="div_box-SAS-q5-basic">
+  <table class="sortable stats_table" id="box-SAS-q5-basic" data-cols-to-freeze=1><caption>San Antonio Spurs (27-7) Table</caption>
+   <colgroup><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col></colgroup>
+   <thead>
+
+      <tr class="over_header"><th></th>
+         <th aria-label="" data-stat="header_tmp" colspan="20" class=" over_header center" >Basic Box Score Stats</th>
+      </tr>
+
+
+
+      <tr>
+         <th aria-label="Starters" data-stat="player" scope="col" class=" poptip sort_default_asc center" >Starters</th>
+         <th aria-label="Minutes Played" data-stat="mp" scope="col" class=" poptip center" data-tip="Minutes Played" data-over-header="Basic Box Score Stats" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" scope="col" class=" poptip center" data-tip="Field Goals" data-over-header="Basic Box Score Stats" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" scope="col" class=" poptip center" data-tip="Field Goal Attempts" data-over-header="Basic Box Score Stats" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" scope="col" class=" poptip center" data-tip="Field Goal Percentage" data-over-header="Basic Box Score Stats" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" scope="col" class=" poptip center" data-tip="3-Point Field Goals" data-over-header="Basic Box Score Stats" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" scope="col" class=" poptip center" data-tip="3-Point Field Goal Attempts" data-over-header="Basic Box Score Stats" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" scope="col" class=" poptip center" data-tip="3-Point Field Goal Percentage" data-over-header="Basic Box Score Stats" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" scope="col" class=" poptip center" data-tip="Free Throws" data-over-header="Basic Box Score Stats" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" scope="col" class=" poptip center" data-tip="Free Throw Attempts" data-over-header="Basic Box Score Stats" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" scope="col" class=" poptip center" data-tip="Free Throw Percentage" data-over-header="Basic Box Score Stats" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" scope="col" class=" poptip center" data-tip="Offensive Rebounds" data-over-header="Basic Box Score Stats" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" scope="col" class=" poptip center" data-tip="Defensive Rebounds" data-over-header="Basic Box Score Stats" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" scope="col" class=" poptip center" data-tip="Total Rebounds" data-over-header="Basic Box Score Stats" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" scope="col" class=" poptip center" data-tip="Assists" data-over-header="Basic Box Score Stats" >AST</th>
+         <th aria-label="Steals" data-stat="stl" scope="col" class=" poptip center" data-tip="Steals" data-over-header="Basic Box Score Stats" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" scope="col" class=" poptip center" data-tip="Blocks" data-over-header="Basic Box Score Stats" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" scope="col" class=" poptip center" data-tip="Turnovers" data-over-header="Basic Box Score Stats" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" scope="col" class=" poptip center" data-tip="Personal Fouls" data-over-header="Basic Box Score Stats" >PF</th>
+         <th aria-label="Points" data-stat="pts" scope="col" class=" poptip center" data-tip="Points" data-over-header="Basic Box Score Stats" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" scope="col" class=" poptip right" data-tip="Plus/Minus" data-over-header="Basic Box Score Stats" >+/-</th>
+      </tr>
+
+   </thead>
+   <tbody>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/a/aldrila01.html'>LaMarcus Aldridge</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/g/gasolpa01.html'>Pau Gasol</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/p/parketo01.html'>Tony Parker</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/g/greenda02.html'>Danny Green</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/l/leonaka01.html'>Kawhi Leonard</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+
+      <tr class="thead">
+         <th aria-label="Reserves" data-stat="player" class=" sort_default_asc center" >Reserves</th>
+         <th aria-label="Minutes Played" data-stat="mp" class=" center" data-tip="Minutes Played" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" class=" center" data-tip="Field Goals" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" class=" center" data-tip="Field Goal Attempts" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" class=" center" data-tip="Field Goal Percentage" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" class=" center" data-tip="3-Point Field Goals" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" class=" center" data-tip="3-Point Field Goal Attempts" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" class=" center" data-tip="3-Point Field Goal Percentage" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" class=" center" data-tip="Free Throws" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" class=" center" data-tip="Free Throw Attempts" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" class=" center" data-tip="Free Throw Percentage" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" class=" center" data-tip="Offensive Rebounds" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" class=" center" data-tip="Defensive Rebounds" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" class=" center" data-tip="Total Rebounds" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" class=" center" data-tip="Assists" >AST</th>
+         <th aria-label="Steals" data-stat="stl" class=" center" data-tip="Steals" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" class=" center" data-tip="Blocks" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" class=" center" data-tip="Turnovers" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" class=" center" data-tip="Personal Fouls" >PF</th>
+         <th aria-label="Points" data-stat="pts" class=" center" data-tip="Points" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" class=" right" data-tip="Plus/Minus" >+/-</th>
+      </tr>
+
+
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/m/millspa02.html'>Patty Mills</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/g/ginobma01.html'>Manu Ginóbili</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/s/simmojo02.html'>Jonathon Simmons</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/l/leeda02.html'>David Lee</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/a/anderky01.html'>Kyle Anderson</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/d/dedmode01.html'>Dewayne Dedmon</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="bertada01" data-stat="player" csk="Bertāns,Dāvis" ><a href="/players/b/bertada01.html">Dāvis Bertāns</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="murrade01" data-stat="player" csk="Murray,Dejounte" ><a href="/players/m/murrade01.html">Dejounte Murray</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+
+   </tbody>
+   <tfoot><tr ><th scope="row" class="left " data-stat="player" >Team Totals</th><td class="right " data-stat="mp" >265</td><td class="right " data-stat="fg" >42</td><td class="right " data-stat="fga" >90</td><td class="right " data-stat="fg_pct" >.467</td><td class="right " data-stat="fg3" >9</td><td class="right " data-stat="fg3a" >27</td><td class="right " data-stat="fg3_pct" >.333</td><td class="right " data-stat="ft" >19</td><td class="right " data-stat="fta" >22</td><td class="right " data-stat="ft_pct" >.864</td><td class="right " data-stat="orb" >9</td><td class="right " data-stat="drb" >38</td><td class="right " data-stat="trb" >47</td><td class="right " data-stat="ast" >27</td><td class="right " data-stat="stl" >5</td><td class="right " data-stat="blk" >6</td><td class="right " data-stat="tov" >12</td><td class="right " data-stat="pf" >21</td><td class="right " data-stat="pts" >112</td><td class="right iz" data-stat="plus_minus" ></td></tr>
+
+   </tfoot>
+
+</table>
+
+      </div>
+   </div>
+</div>
+
+
+    </div>
+
+</div>
+<div class="section_wrapper box-SAS box-SAS-game" id="all_box-SAS-game-advanced">    <div class="section_content" id="div_box-SAS-game-advanced">
+
+<div id="all_box-SAS-game-advanced" class="table_wrapper">
+
+<div class="section_heading">
+  <span class="section_anchor" id="box-SAS-game-advanced_link" data-label=""></span><h2></h2>    <div class="section_heading_text">
+      <ul>
+      </ul>
+    </div>
+
+</div>   <div class="table_outer_container">
+      <div class="overthrow table_container" id="div_box-SAS-game-advanced">
+  <table class="sortable stats_table" id="box-SAS-game-advanced" data-cols-to-freeze=1><caption> Table</caption>
    <colgroup><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col></colgroup>
    <thead>
 
@@ -774,12 +1595,12 @@ sr_menus_setupMainNav_button_inline();
 
 
 <tr ><th scope="row" class="left " data-append-csv="millspa02" data-stat="player" csk="Mills,Patty" ><a href="/players/m/millspa02.html">Patty Mills</a></th><td class="right " data-stat="mp" csk="1274" >21:14</td><td class="right " data-stat="ts_pct" >.313</td><td class="right " data-stat="efg_pct" >.313</td><td class="right " data-stat="fg3a_per_fga_pct" >.500</td><td class="right " data-stat="fta_per_fga_pct" >.000</td><td class="right " data-stat="orb_pct" >0.0</td><td class="right " data-stat="drb_pct" >0.0</td><td class="right " data-stat="trb_pct" >0.0</td><td class="right " data-stat="ast_pct" >20.2</td><td class="right " data-stat="stl_pct" >0.0</td><td class="right " data-stat="blk_pct" >0.0</td><td class="right " data-stat="tov_pct" >0.0</td><td class="right " data-stat="usg_pct" >17.9</td><td class="right " data-stat="off_rtg" >83</td><td class="right " data-stat="def_rtg" >121</td></tr>
-<tr ><th scope="row" class="left " data-append-csv="ginobma01" data-stat="player" csk="Ginobili,Manu" ><a href="/players/g/ginobma01.html">Manu Ginobili</a></th><td class="right " data-stat="mp" csk="1245" >20:45</td><td class="right " data-stat="ts_pct" >.694</td><td class="right " data-stat="efg_pct" >.500</td><td class="right " data-stat="fg3a_per_fga_pct" >.600</td><td class="right " data-stat="fta_per_fga_pct" >1.000</td><td class="right " data-stat="orb_pct" >0.0</td><td class="right " data-stat="drb_pct" >15.6</td><td class="right " data-stat="trb_pct" >8.2</td><td class="right " data-stat="ast_pct" >20.8</td><td class="right " data-stat="stl_pct" >7.6</td><td class="right " data-stat="blk_pct" >0.0</td><td class="right " data-stat="tov_pct" >12.2</td><td class="right " data-stat="usg_pct" >18.8</td><td class="right " data-stat="off_rtg" >136</td><td class="right " data-stat="def_rtg" >99</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="ginobma01" data-stat="player" csk="Ginóbili,Manu" ><a href="/players/g/ginobma01.html">Manu Ginóbili</a></th><td class="right " data-stat="mp" csk="1245" >20:45</td><td class="right " data-stat="ts_pct" >.694</td><td class="right " data-stat="efg_pct" >.500</td><td class="right " data-stat="fg3a_per_fga_pct" >.600</td><td class="right " data-stat="fta_per_fga_pct" >1.000</td><td class="right " data-stat="orb_pct" >0.0</td><td class="right " data-stat="drb_pct" >15.6</td><td class="right " data-stat="trb_pct" >8.2</td><td class="right " data-stat="ast_pct" >20.8</td><td class="right " data-stat="stl_pct" >7.6</td><td class="right " data-stat="blk_pct" >0.0</td><td class="right " data-stat="tov_pct" >12.2</td><td class="right " data-stat="usg_pct" >18.8</td><td class="right " data-stat="off_rtg" >136</td><td class="right " data-stat="def_rtg" >99</td></tr>
 <tr ><th scope="row" class="left " data-append-csv="simmojo02" data-stat="player" csk="Simmons,Jonathon" ><a href="/players/s/simmojo02.html">Jonathon Simmons</a></th><td class="right " data-stat="mp" csk="1126" >18:46</td><td class="right " data-stat="ts_pct" >.000</td><td class="right " data-stat="efg_pct" >.000</td><td class="right " data-stat="fg3a_per_fga_pct" >1.000</td><td class="right " data-stat="fta_per_fga_pct" >.000</td><td class="right " data-stat="orb_pct" >6.4</td><td class="right " data-stat="drb_pct" >11.5</td><td class="right " data-stat="trb_pct" >9.1</td><td class="right " data-stat="ast_pct" >20.2</td><td class="right " data-stat="stl_pct" >0.0</td><td class="right " data-stat="blk_pct" >4.4</td><td class="right " data-stat="tov_pct" >0.0</td><td class="right " data-stat="usg_pct" >5.1</td><td class="right " data-stat="off_rtg" >91</td><td class="right " data-stat="def_rtg" >114</td></tr>
 <tr ><th scope="row" class="left " data-append-csv="leeda02" data-stat="player" csk="Lee,David" ><a href="/players/l/leeda02.html">David Lee</a></th><td class="right " data-stat="mp" csk="1102" >18:22</td><td class="right " data-stat="ts_pct" >.444</td><td class="right " data-stat="efg_pct" >.444</td><td class="right " data-stat="fg3a_per_fga_pct" >.000</td><td class="right " data-stat="fta_per_fga_pct" >.000</td><td class="right " data-stat="orb_pct" >6.6</td><td class="right " data-stat="drb_pct" >11.8</td><td class="right " data-stat="trb_pct" >9.3</td><td class="right " data-stat="ast_pct" >18.9</td><td class="right " data-stat="stl_pct" >0.0</td><td class="right " data-stat="blk_pct" >0.0</td><td class="right " data-stat="tov_pct" >18.2</td><td class="right " data-stat="usg_pct" >28.4</td><td class="right " data-stat="off_rtg" >83</td><td class="right " data-stat="def_rtg" >117</td></tr>
 <tr ><th scope="row" class="left " data-append-csv="anderky01" data-stat="player" csk="Anderson,Kyle" ><a href="/players/a/anderky01.html">Kyle Anderson</a></th><td class="right " data-stat="mp" csk="468" >7:48</td><td class="right iz" data-stat="ts_pct" ></td><td class="right iz" data-stat="efg_pct" ></td><td class="right iz" data-stat="fg3a_per_fga_pct" ></td><td class="right iz" data-stat="fta_per_fga_pct" ></td><td class="right " data-stat="orb_pct" >0.0</td><td class="right " data-stat="drb_pct" >13.9</td><td class="right " data-stat="trb_pct" >7.3</td><td class="right " data-stat="ast_pct" >16.2</td><td class="right " data-stat="stl_pct" >0.0</td><td class="right " data-stat="blk_pct" >0.0</td><td class="right " data-stat="tov_pct" >100.0</td><td class="right " data-stat="usg_pct" >6.1</td><td class="right " data-stat="off_rtg" >43</td><td class="right " data-stat="def_rtg" >116</td></tr>
 <tr ><th scope="row" class="left " data-append-csv="dedmode01" data-stat="player" csk="Dedmon,Dewayne" ><a href="/players/d/dedmode01.html">Dewayne Dedmon</a></th><td class="right " data-stat="mp" csk="343" >5:43</td><td class="right " data-stat="ts_pct" >.000</td><td class="right " data-stat="efg_pct" >.000</td><td class="right " data-stat="fg3a_per_fga_pct" >.000</td><td class="right " data-stat="fta_per_fga_pct" >.000</td><td class="right " data-stat="orb_pct" >0.0</td><td class="right " data-stat="drb_pct" >37.8</td><td class="right " data-stat="trb_pct" >19.9</td><td class="right " data-stat="ast_pct" >0.0</td><td class="right " data-stat="stl_pct" >0.0</td><td class="right " data-stat="blk_pct" >0.0</td><td class="right " data-stat="tov_pct" >50.0</td><td class="right " data-stat="usg_pct" >16.6</td><td class="right iz" data-stat="off_rtg" >0</td><td class="right " data-stat="def_rtg" >107</td></tr>
-<tr ><th scope="row" class="left " data-append-csv="bertada01" data-stat="player" csk="Bertans,Davis" ><a href="/players/b/bertada01.html">Davis Bertans</a></th><td class="center " data-stat="reason" colspan=15 class='italic_text gray_text' >Did Not Play</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="bertada01" data-stat="player" csk="Bertāns,Dāvis" ><a href="/players/b/bertada01.html">Dāvis Bertāns</a></th><td class="center " data-stat="reason" colspan=15 class='italic_text gray_text' >Did Not Play</td></tr>
 <tr ><th scope="row" class="left " data-append-csv="murrade01" data-stat="player" csk="Murray,Dejounte" ><a href="/players/m/murrade01.html">Dejounte Murray</a></th><td class="center " data-stat="reason" colspan=15 class='italic_text gray_text' >Did Not Play</td></tr>
 
    </tbody>
@@ -793,16 +1614,23 @@ sr_menus_setupMainNav_button_inline();
    </div>
 </div>
 
-<div id="all_box_atl_basic" class="table_wrapper">
+
+    </div>
+
+</div>
+<div><button class='sr_preset tooltip' data-hide='.box-ATL' data-show='.box-ATL-game'>Game</button>&nbsp;&#183; <button class='sr_preset tooltip' data-hide='.box-ATL' data-show='.box-ATL-q1'>Q1</button>&nbsp;&#183; <button class='sr_preset tooltip' data-hide='.box-ATL' data-show='.box-ATL-q2'>Q2</button>&nbsp;&#183; <button class='sr_preset tooltip' data-hide='.box-ATL' data-show='.box-ATL-h1'>H1</button>&nbsp;&#183; <button class='sr_preset tooltip' data-hide='.box-ATL' data-show='.box-ATL-q3'>Q3</button>&nbsp;&#183; <button class='sr_preset tooltip' data-hide='.box-ATL' data-show='.box-ATL-q4'>Q4</button>&nbsp;&#183; <button class='sr_preset tooltip' data-hide='.box-ATL' data-show='.box-ATL-h2'>H2</button>&nbsp;&#183; <button class='sr_preset tooltip' data-hide='.box-ATL' data-show='.box-ATL-q5'>Q5</button></div><div class="section_wrapper box-ATL box-ATL-game" id="all_box-ATL-game-basic">    <div class="section_content" id="div_box-ATL-game-basic">
+
+<div id="all_box-ATL-game-basic" class="table_wrapper">
 
 <div class="section_heading">
-  <span class="section_anchor" id="box_atl_basic_link" data-label="Atlanta Hawks (18-16)"></span><h2>Atlanta Hawks (18-16)</h2>    <div class="section_heading_text">
+  <span class="section_anchor" id="box-ATL-game-basic_link" data-label="Atlanta Hawks (18-16)"></span><h2>Atlanta Hawks (18-16)</h2>    <div class="section_heading_text">
       <ul>
       </ul>
     </div>
+
 </div>   <div class="table_outer_container">
-      <div class="overthrow table_container" id="div_box_atl_basic">
-  <table class="sortable stats_table" id="box_atl_basic" data-cols-to-freeze=1><caption>Atlanta Hawks (18-16) Table</caption>
+      <div class="overthrow table_container" id="div_box-ATL-game-basic">
+  <table class="sortable stats_table" id="box-ATL-game-basic" data-cols-to-freeze=1><caption>Atlanta Hawks (18-16) Table</caption>
    <colgroup><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col></colgroup>
    <thead>
 
@@ -840,7 +1668,7 @@ sr_menus_setupMainNav_button_inline();
    <tbody>
 <tr ><th scope="row" class="left " data-append-csv="millspa01" data-stat="player" csk="Millsap,Paul" ><a href="/players/m/millspa01.html">Paul Millsap</a></th><td class="right " data-stat="mp" csk="2805" >46:45</td><td class="right " data-stat="fg" >11</td><td class="right " data-stat="fga" >23</td><td class="right " data-stat="fg_pct" >.478</td><td class="right " data-stat="fg3" >3</td><td class="right " data-stat="fg3a" >6</td><td class="right " data-stat="fg3_pct" >.500</td><td class="right " data-stat="ft" >7</td><td class="right " data-stat="fta" >10</td><td class="right " data-stat="ft_pct" >.700</td><td class="right " data-stat="orb" >3</td><td class="right " data-stat="drb" >10</td><td class="right " data-stat="trb" >13</td><td class="right " data-stat="ast" >3</td><td class="right iz" data-stat="stl" >0</td><td class="right " data-stat="blk" >1</td><td class="right " data-stat="tov" >2</td><td class="right " data-stat="pf" >5</td><td class="right " data-stat="pts" >32</td><td class="right " data-stat="plus_minus" >-5</td></tr>
 <tr ><th scope="row" class="left " data-append-csv="howardw01" data-stat="player" csk="Howard,Dwight" ><a href="/players/h/howardw01.html">Dwight Howard</a></th><td class="right " data-stat="mp" csk="2057" >34:17</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >4</td><td class="right " data-stat="fg_pct" >.500</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right " data-stat="ft" >2</td><td class="right " data-stat="fta" >4</td><td class="right " data-stat="ft_pct" >.500</td><td class="right " data-stat="orb" >4</td><td class="right " data-stat="drb" >4</td><td class="right " data-stat="trb" >8</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right " data-stat="blk" >1</td><td class="right " data-stat="tov" >2</td><td class="right " data-stat="pf" >4</td><td class="right " data-stat="pts" >6</td><td class="right " data-stat="plus_minus" >-7</td></tr>
-<tr ><th scope="row" class="left " data-append-csv="schrode01" data-stat="player" csk="Schroder,Dennis" ><a href="/players/s/schrode01.html">Dennis Schroder</a></th><td class="right " data-stat="mp" csk="2005" >33:25</td><td class="right " data-stat="fg" >7</td><td class="right " data-stat="fga" >17</td><td class="right " data-stat="fg_pct" >.412</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >2</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right " data-stat="ft" >2</td><td class="right " data-stat="fta" >3</td><td class="right " data-stat="ft_pct" >.667</td><td class="right " data-stat="orb" >1</td><td class="right iz" data-stat="drb" >0</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >10</td><td class="right iz" data-stat="stl" >0</td><td class="right " data-stat="blk" >1</td><td class="right " data-stat="tov" >3</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >16</td><td class="right " data-stat="plus_minus" >-7</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="schrode01" data-stat="player" csk="Schröder,Dennis" ><a href="/players/s/schrode01.html">Dennis Schröder</a></th><td class="right " data-stat="mp" csk="2005" >33:25</td><td class="right " data-stat="fg" >7</td><td class="right " data-stat="fga" >17</td><td class="right " data-stat="fg_pct" >.412</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >2</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right " data-stat="ft" >2</td><td class="right " data-stat="fta" >3</td><td class="right " data-stat="ft_pct" >.667</td><td class="right " data-stat="orb" >1</td><td class="right iz" data-stat="drb" >0</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >10</td><td class="right iz" data-stat="stl" >0</td><td class="right " data-stat="blk" >1</td><td class="right " data-stat="tov" >3</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >16</td><td class="right " data-stat="plus_minus" >-7</td></tr>
 <tr ><th scope="row" class="left " data-append-csv="bazemke01" data-stat="player" csk="Bazemore,Kent" ><a href="/players/b/bazemke01.html">Kent Bazemore</a></th><td class="right " data-stat="mp" csk="1146" >19:06</td><td class="right " data-stat="fg" >3</td><td class="right " data-stat="fga" >10</td><td class="right " data-stat="fg_pct" >.300</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >2</td><td class="right " data-stat="fg3_pct" >.500</td><td class="right " data-stat="ft" >1</td><td class="right " data-stat="fta" >4</td><td class="right " data-stat="ft_pct" >.250</td><td class="right " data-stat="orb" >1</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >2</td><td class="right iz" data-stat="ast" >0</td><td class="right " data-stat="stl" >2</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >3</td><td class="right " data-stat="pts" >8</td><td class="right " data-stat="plus_minus" >-16</td></tr>
 <tr ><th scope="row" class="left " data-append-csv="sefolth01" data-stat="player" csk="Sefolosha,Thabo" ><a href="/players/s/sefolth01.html">Thabo Sefolosha</a></th><td class="right " data-stat="mp" csk="979" >16:19</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >3</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right " data-stat="ft" >3</td><td class="right " data-stat="fta" >4</td><td class="right " data-stat="ft_pct" >.750</td><td class="right " data-stat="orb" >1</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >2</td><td class="right " data-stat="ast" >1</td><td class="right " data-stat="stl" >1</td><td class="right " data-stat="blk" >1</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >3</td><td class="right " data-stat="pts" >3</td><td class="right " data-stat="plus_minus" >-9</td></tr>
 
@@ -888,16 +1716,737 @@ sr_menus_setupMainNav_button_inline();
    </div>
 </div>
 
-<div id="all_box_atl_advanced" class="table_wrapper">
+
+    </div>
+
+</div>
+<div class="section_wrapper toggleable box-ATL box-ATL-q1" id="all_box-ATL-q1-basic">    <div class="section_content" id="div_box-ATL-q1-basic">
+
+<div id="all_box-ATL-q1-basic" class="table_wrapper">
 
 <div class="section_heading">
-  <span class="section_anchor" id="box_atl_advanced_link" data-label=""></span><h2></h2>    <div class="section_heading_text">
+  <span class="section_anchor" id="box-ATL-q1-basic_link" data-label="Atlanta Hawks (18-16)"></span><h2>Atlanta Hawks (18-16)</h2>    <div class="section_heading_text">
       <ul>
       </ul>
     </div>
+
 </div>   <div class="table_outer_container">
-      <div class="overthrow table_container" id="div_box_atl_advanced">
-  <table class="sortable stats_table" id="box_atl_advanced" data-cols-to-freeze=1><caption> Table</caption>
+      <div class="overthrow table_container" id="div_box-ATL-q1-basic">
+  <table class="sortable stats_table" id="box-ATL-q1-basic" data-cols-to-freeze=1><caption>Atlanta Hawks (18-16) Table</caption>
+   <colgroup><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col></colgroup>
+   <thead>
+
+      <tr class="over_header"><th></th>
+         <th aria-label="" data-stat="header_tmp" colspan="20" class=" over_header center" >Basic Box Score Stats</th>
+      </tr>
+
+
+
+      <tr>
+         <th aria-label="Starters" data-stat="player" scope="col" class=" poptip sort_default_asc center" >Starters</th>
+         <th aria-label="Minutes Played" data-stat="mp" scope="col" class=" poptip center" data-tip="Minutes Played" data-over-header="Basic Box Score Stats" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" scope="col" class=" poptip center" data-tip="Field Goals" data-over-header="Basic Box Score Stats" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" scope="col" class=" poptip center" data-tip="Field Goal Attempts" data-over-header="Basic Box Score Stats" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" scope="col" class=" poptip center" data-tip="Field Goal Percentage" data-over-header="Basic Box Score Stats" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" scope="col" class=" poptip center" data-tip="3-Point Field Goals" data-over-header="Basic Box Score Stats" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" scope="col" class=" poptip center" data-tip="3-Point Field Goal Attempts" data-over-header="Basic Box Score Stats" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" scope="col" class=" poptip center" data-tip="3-Point Field Goal Percentage" data-over-header="Basic Box Score Stats" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" scope="col" class=" poptip center" data-tip="Free Throws" data-over-header="Basic Box Score Stats" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" scope="col" class=" poptip center" data-tip="Free Throw Attempts" data-over-header="Basic Box Score Stats" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" scope="col" class=" poptip center" data-tip="Free Throw Percentage" data-over-header="Basic Box Score Stats" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" scope="col" class=" poptip center" data-tip="Offensive Rebounds" data-over-header="Basic Box Score Stats" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" scope="col" class=" poptip center" data-tip="Defensive Rebounds" data-over-header="Basic Box Score Stats" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" scope="col" class=" poptip center" data-tip="Total Rebounds" data-over-header="Basic Box Score Stats" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" scope="col" class=" poptip center" data-tip="Assists" data-over-header="Basic Box Score Stats" >AST</th>
+         <th aria-label="Steals" data-stat="stl" scope="col" class=" poptip center" data-tip="Steals" data-over-header="Basic Box Score Stats" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" scope="col" class=" poptip center" data-tip="Blocks" data-over-header="Basic Box Score Stats" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" scope="col" class=" poptip center" data-tip="Turnovers" data-over-header="Basic Box Score Stats" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" scope="col" class=" poptip center" data-tip="Personal Fouls" data-over-header="Basic Box Score Stats" >PF</th>
+         <th aria-label="Points" data-stat="pts" scope="col" class=" poptip center" data-tip="Points" data-over-header="Basic Box Score Stats" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" scope="col" class=" poptip right" data-tip="Plus/Minus" data-over-header="Basic Box Score Stats" >+/-</th>
+      </tr>
+
+   </thead>
+   <tbody>
+<tr ><th scope="row" class="left " data-append-csv="millspa01" data-stat="player" csk="Millsap,Paul" ><a href="/players/m/millspa01.html">Paul Millsap</a></th><td class="right " data-stat="mp" csk="720" >12:00</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >4</td><td class="right " data-stat="fg_pct" >.500</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right " data-stat="fta" >1</td><td class="right " data-stat="ft_pct" >.000</td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >4</td><td class="right " data-stat="trb" >4</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >4</td><td class="right " data-stat="plus_minus" >-2</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="howardw01" data-stat="player" csk="Howard,Dwight" ><a href="/players/h/howardw01.html">Dwight Howard</a></th><td class="right " data-stat="mp" csk="517" >8:37</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >4</td><td class="right " data-stat="fg_pct" >.500</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right " data-stat="ft" >2</td><td class="right " data-stat="fta" >2</td><td class="right " data-stat="ft_pct" >1.000</td><td class="right " data-stat="orb" >1</td><td class="right iz" data-stat="drb" >0</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >6</td><td class="right " data-stat="plus_minus" >-3</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="schrode01" data-stat="player" csk="Schröder,Dennis" ><a href="/players/s/schrode01.html">Dennis Schröder</a></th><td class="right " data-stat="mp" csk="517" >8:37</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >4</td><td class="right " data-stat="fg_pct" >.500</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right " data-stat="orb" >1</td><td class="right iz" data-stat="drb" >0</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >3</td><td class="right iz" data-stat="stl" >0</td><td class="right " data-stat="blk" >1</td><td class="right " data-stat="tov" >1</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >4</td><td class="right " data-stat="plus_minus" >-3</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="bazemke01" data-stat="player" csk="Bazemore,Kent" ><a href="/players/b/bazemke01.html">Kent Bazemore</a></th><td class="right " data-stat="mp" csk="433" >7:13</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >3</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right " data-stat="ft" >1</td><td class="right " data-stat="fta" >2</td><td class="right " data-stat="ft_pct" >.500</td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right iz" data-stat="ast" >0</td><td class="right " data-stat="stl" >2</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >1</td><td class="right " data-stat="plus_minus" >-5</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="sefolth01" data-stat="player" csk="Sefolosha,Thabo" ><a href="/players/s/sefolth01.html">Thabo Sefolosha</a></th><td class="right " data-stat="mp" csk="456" >7:36</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >2</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right " data-stat="orb" >1</td><td class="right iz" data-stat="drb" >0</td><td class="right " data-stat="trb" >1</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right " data-stat="blk" >1</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right iz" data-stat="pts" >0</td><td class="right iz" data-stat="plus_minus" >0</td></tr>
+
+      <tr class="thead">
+         <th aria-label="Reserves" data-stat="player" class=" sort_default_asc center" >Reserves</th>
+         <th aria-label="Minutes Played" data-stat="mp" class=" center" data-tip="Minutes Played" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" class=" center" data-tip="Field Goals" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" class=" center" data-tip="Field Goal Attempts" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" class=" center" data-tip="Field Goal Percentage" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" class=" center" data-tip="3-Point Field Goals" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" class=" center" data-tip="3-Point Field Goal Attempts" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" class=" center" data-tip="3-Point Field Goal Percentage" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" class=" center" data-tip="Free Throws" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" class=" center" data-tip="Free Throw Attempts" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" class=" center" data-tip="Free Throw Percentage" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" class=" center" data-tip="Offensive Rebounds" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" class=" center" data-tip="Defensive Rebounds" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" class=" center" data-tip="Total Rebounds" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" class=" center" data-tip="Assists" >AST</th>
+         <th aria-label="Steals" data-stat="stl" class=" center" data-tip="Steals" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" class=" center" data-tip="Blocks" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" class=" center" data-tip="Turnovers" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" class=" center" data-tip="Personal Fouls" >PF</th>
+         <th aria-label="Points" data-stat="pts" class=" center" data-tip="Points" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" class=" right" data-tip="Plus/Minus" >+/-</th>
+      </tr>
+
+
+<tr ><th scope="row" class="left " data-append-csv="korveky01" data-stat="player" csk="Korver,Kyle" ><a href="/players/k/korveky01.html">Kyle Korver</a></th><td class="right " data-stat="mp" csk="428" >7:08</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >4</td><td class="right " data-stat="fg_pct" >.500</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >2</td><td class="right " data-stat="fg3_pct" >.500</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right iz" data-stat="ast" >0</td><td class="right " data-stat="stl" >1</td><td class="right " data-stat="blk" >1</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >5</td><td class="right iz" data-stat="plus_minus" >0</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="hardati02" data-stat="player" csk="Hardaway,Tim" ><a href="/players/h/hardati02.html">Tim Hardaway</a></th><td class="right " data-stat="mp" csk="123" >2:03</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >1</td><td class="right " data-stat="fg_pct" >1.000</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >1.000</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >3</td><td class="right " data-stat="plus_minus" >+1</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="delanma01" data-stat="player" csk="Delaney,Malcolm" ><a href="/players/d/delanma01.html">Malcolm Delaney</a></th><td class="right " data-stat="mp" csk="203" >3:23</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >2</td><td class="right " data-stat="fg_pct" >.500</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >2</td><td class="right " data-stat="plus_minus" >+1</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="muscami01" data-stat="player" csk="Muscala,Mike" ><a href="/players/m/muscami01.html">Mike Muscala</a></th><td class="right " data-stat="mp" csk="203" >3:23</td><td class="right iz" data-stat="fg" >0</td><td class="right iz" data-stat="fga" >0</td><td class="right iz" data-stat="fg_pct" ></td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >+1</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/h/humphkr01.html'>Kris Humphries</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="bembrde01" data-stat="player" csk="Bembry,DeAndre'" ><a href="/players/b/bembrde01.html">DeAndre' Bembry</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="kellyry01" data-stat="player" csk="Kelly,Ryan" ><a href="/players/k/kellyry01.html">Ryan Kelly</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+
+   </tbody>
+   <tfoot><tr ><th scope="row" class="left " data-stat="player" >Team Totals</th><td class="right " data-stat="mp" >265</td><td class="right " data-stat="fg" >42</td><td class="right " data-stat="fga" >92</td><td class="right " data-stat="fg_pct" >.457</td><td class="right " data-stat="fg3" >14</td><td class="right " data-stat="fg3a" >28</td><td class="right " data-stat="fg3_pct" >.500</td><td class="right " data-stat="ft" >16</td><td class="right " data-stat="fta" >27</td><td class="right " data-stat="ft_pct" >.593</td><td class="right " data-stat="orb" >11</td><td class="right " data-stat="drb" >35</td><td class="right " data-stat="trb" >46</td><td class="right " data-stat="ast" >25</td><td class="right " data-stat="stl" >6</td><td class="right " data-stat="blk" >6</td><td class="right " data-stat="tov" >11</td><td class="right " data-stat="pf" >21</td><td class="right " data-stat="pts" >114</td><td class="right iz" data-stat="plus_minus" ></td></tr>
+
+   </tfoot>
+
+</table>
+
+      </div>
+   </div>
+</div>
+
+
+    </div>
+
+</div>
+<div class="section_wrapper toggleable box-ATL box-ATL-q2" id="all_box-ATL-q2-basic">    <div class="section_content" id="div_box-ATL-q2-basic">
+
+<div id="all_box-ATL-q2-basic" class="table_wrapper">
+
+<div class="section_heading">
+  <span class="section_anchor" id="box-ATL-q2-basic_link" data-label="Atlanta Hawks (18-16)"></span><h2>Atlanta Hawks (18-16)</h2>    <div class="section_heading_text">
+      <ul>
+      </ul>
+    </div>
+
+</div>   <div class="table_outer_container">
+      <div class="overthrow table_container" id="div_box-ATL-q2-basic">
+  <table class="sortable stats_table" id="box-ATL-q2-basic" data-cols-to-freeze=1><caption>Atlanta Hawks (18-16) Table</caption>
+   <colgroup><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col></colgroup>
+   <thead>
+
+      <tr class="over_header"><th></th>
+         <th aria-label="" data-stat="header_tmp" colspan="20" class=" over_header center" >Basic Box Score Stats</th>
+      </tr>
+
+
+
+      <tr>
+         <th aria-label="Starters" data-stat="player" scope="col" class=" poptip sort_default_asc center" >Starters</th>
+         <th aria-label="Minutes Played" data-stat="mp" scope="col" class=" poptip center" data-tip="Minutes Played" data-over-header="Basic Box Score Stats" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" scope="col" class=" poptip center" data-tip="Field Goals" data-over-header="Basic Box Score Stats" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" scope="col" class=" poptip center" data-tip="Field Goal Attempts" data-over-header="Basic Box Score Stats" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" scope="col" class=" poptip center" data-tip="Field Goal Percentage" data-over-header="Basic Box Score Stats" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" scope="col" class=" poptip center" data-tip="3-Point Field Goals" data-over-header="Basic Box Score Stats" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" scope="col" class=" poptip center" data-tip="3-Point Field Goal Attempts" data-over-header="Basic Box Score Stats" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" scope="col" class=" poptip center" data-tip="3-Point Field Goal Percentage" data-over-header="Basic Box Score Stats" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" scope="col" class=" poptip center" data-tip="Free Throws" data-over-header="Basic Box Score Stats" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" scope="col" class=" poptip center" data-tip="Free Throw Attempts" data-over-header="Basic Box Score Stats" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" scope="col" class=" poptip center" data-tip="Free Throw Percentage" data-over-header="Basic Box Score Stats" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" scope="col" class=" poptip center" data-tip="Offensive Rebounds" data-over-header="Basic Box Score Stats" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" scope="col" class=" poptip center" data-tip="Defensive Rebounds" data-over-header="Basic Box Score Stats" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" scope="col" class=" poptip center" data-tip="Total Rebounds" data-over-header="Basic Box Score Stats" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" scope="col" class=" poptip center" data-tip="Assists" data-over-header="Basic Box Score Stats" >AST</th>
+         <th aria-label="Steals" data-stat="stl" scope="col" class=" poptip center" data-tip="Steals" data-over-header="Basic Box Score Stats" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" scope="col" class=" poptip center" data-tip="Blocks" data-over-header="Basic Box Score Stats" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" scope="col" class=" poptip center" data-tip="Turnovers" data-over-header="Basic Box Score Stats" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" scope="col" class=" poptip center" data-tip="Personal Fouls" data-over-header="Basic Box Score Stats" >PF</th>
+         <th aria-label="Points" data-stat="pts" scope="col" class=" poptip center" data-tip="Points" data-over-header="Basic Box Score Stats" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" scope="col" class=" poptip right" data-tip="Plus/Minus" data-over-header="Basic Box Score Stats" >+/-</th>
+      </tr>
+
+   </thead>
+   <tbody>
+<tr ><th scope="row" class="left " data-append-csv="millspa01" data-stat="player" csk="Millsap,Paul" ><a href="/players/m/millspa01.html">Paul Millsap</a></th><td class="right " data-stat="mp" csk="345" >5:45</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >2</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right " data-stat="ft" >1</td><td class="right " data-stat="fta" >2</td><td class="right " data-stat="ft_pct" >.500</td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right " data-stat="blk" >1</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >1</td><td class="right " data-stat="plus_minus" >-7</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="howardw01" data-stat="player" csk="Howard,Dwight" ><a href="/players/h/howardw01.html">Dwight Howard</a></th><td class="right " data-stat="mp" csk="300" >5:00</td><td class="right iz" data-stat="fg" >0</td><td class="right iz" data-stat="fga" >0</td><td class="right iz" data-stat="fg_pct" ></td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right " data-stat="fta" >2</td><td class="right " data-stat="ft_pct" >.000</td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >1</td><td class="right " data-stat="pf" >2</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >-7</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="schrode01" data-stat="player" csk="Schröder,Dennis" ><a href="/players/s/schrode01.html">Dennis Schröder</a></th><td class="right " data-stat="mp" csk="226" >3:46</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >2</td><td class="right " data-stat="fg_pct" >.500</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >2</td><td class="right " data-stat="plus_minus" >-4</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="bazemke01" data-stat="player" csk="Bazemore,Kent" ><a href="/players/b/bazemke01.html">Kent Bazemore</a></th><td class="right " data-stat="mp" csk="226" >3:46</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >2</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >-4</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="sefolth01" data-stat="player" csk="Sefolosha,Thabo" ><a href="/players/s/sefolth01.html">Thabo Sefolosha</a></th><td class="right " data-stat="mp" csk="252" >4:12</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >1</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right " data-stat="ft" >1</td><td class="right " data-stat="fta" >2</td><td class="right " data-stat="ft_pct" >.500</td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >1</td><td class="right " data-stat="plus_minus" >-7</td></tr>
+
+      <tr class="thead">
+         <th aria-label="Reserves" data-stat="player" class=" sort_default_asc center" >Reserves</th>
+         <th aria-label="Minutes Played" data-stat="mp" class=" center" data-tip="Minutes Played" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" class=" center" data-tip="Field Goals" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" class=" center" data-tip="Field Goal Attempts" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" class=" center" data-tip="Field Goal Percentage" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" class=" center" data-tip="3-Point Field Goals" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" class=" center" data-tip="3-Point Field Goal Attempts" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" class=" center" data-tip="3-Point Field Goal Percentage" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" class=" center" data-tip="Free Throws" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" class=" center" data-tip="Free Throw Attempts" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" class=" center" data-tip="Free Throw Percentage" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" class=" center" data-tip="Offensive Rebounds" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" class=" center" data-tip="Defensive Rebounds" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" class=" center" data-tip="Total Rebounds" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" class=" center" data-tip="Assists" >AST</th>
+         <th aria-label="Steals" data-stat="stl" class=" center" data-tip="Steals" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" class=" center" data-tip="Blocks" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" class=" center" data-tip="Turnovers" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" class=" center" data-tip="Personal Fouls" >PF</th>
+         <th aria-label="Points" data-stat="pts" class=" center" data-tip="Points" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" class=" right" data-tip="Plus/Minus" >+/-</th>
+      </tr>
+
+
+<tr ><th scope="row" class="left " data-append-csv="korveky01" data-stat="player" csk="Korver,Kyle" ><a href="/players/k/korveky01.html">Kyle Korver</a></th><td class="right " data-stat="mp" csk="468" >7:48</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >3</td><td class="right " data-stat="fg_pct" >.667</td><td class="right " data-stat="fg3" >2</td><td class="right " data-stat="fg3a" >2</td><td class="right " data-stat="fg3_pct" >1.000</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >3</td><td class="right " data-stat="trb" >3</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >6</td><td class="right " data-stat="plus_minus" >+7</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="hardati02" data-stat="player" csk="Hardaway,Tim" ><a href="/players/h/hardati02.html">Tim Hardaway</a></th><td class="right " data-stat="mp" csk="494" >8:14</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >2</td><td class="right " data-stat="fg_pct" >1.000</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >1.000</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >5</td><td class="right " data-stat="plus_minus" >+4</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="delanma01" data-stat="player" csk="Delaney,Malcolm" ><a href="/players/d/delanma01.html">Malcolm Delaney</a></th><td class="right " data-stat="mp" csk="494" >8:14</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >2</td><td class="right " data-stat="fg_pct" >.500</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >2</td><td class="right " data-stat="trb" >2</td><td class="right " data-stat="ast" >2</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >2</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >2</td><td class="right " data-stat="plus_minus" >+4</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="muscami01" data-stat="player" csk="Muscala,Mike" ><a href="/players/m/muscami01.html">Mike Muscala</a></th><td class="right " data-stat="mp" csk="420" >7:00</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >3</td><td class="right " data-stat="fg_pct" >.333</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right iz" data-stat="ast" >0</td><td class="right " data-stat="stl" >1</td><td class="right " data-stat="blk" >1</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >2</td><td class="right " data-stat="plus_minus" >+7</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="humphkr01" data-stat="player" csk="Humphries,Kris" ><a href="/players/h/humphkr01.html">Kris Humphries</a></th><td class="right " data-stat="mp" csk="375" >6:15</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >1</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >2</td><td class="right " data-stat="trb" >2</td><td class="right iz" data-stat="ast" >0</td><td class="right " data-stat="stl" >1</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >+7</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="bembrde01" data-stat="player" csk="Bembry,DeAndre'" ><a href="/players/b/bembrde01.html">DeAndre' Bembry</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="kellyry01" data-stat="player" csk="Kelly,Ryan" ><a href="/players/k/kellyry01.html">Ryan Kelly</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+
+   </tbody>
+   <tfoot><tr ><th scope="row" class="left " data-stat="player" >Team Totals</th><td class="right " data-stat="mp" >265</td><td class="right " data-stat="fg" >42</td><td class="right " data-stat="fga" >92</td><td class="right " data-stat="fg_pct" >.457</td><td class="right " data-stat="fg3" >14</td><td class="right " data-stat="fg3a" >28</td><td class="right " data-stat="fg3_pct" >.500</td><td class="right " data-stat="ft" >16</td><td class="right " data-stat="fta" >27</td><td class="right " data-stat="ft_pct" >.593</td><td class="right " data-stat="orb" >11</td><td class="right " data-stat="drb" >35</td><td class="right " data-stat="trb" >46</td><td class="right " data-stat="ast" >25</td><td class="right " data-stat="stl" >6</td><td class="right " data-stat="blk" >6</td><td class="right " data-stat="tov" >11</td><td class="right " data-stat="pf" >21</td><td class="right " data-stat="pts" >114</td><td class="right iz" data-stat="plus_minus" ></td></tr>
+
+   </tfoot>
+
+</table>
+
+      </div>
+   </div>
+</div>
+
+
+    </div>
+
+</div>
+<div class="section_wrapper toggleable box-ATL box-ATL-h1" id="all_box-ATL-h1-basic">    <div class="section_content" id="div_box-ATL-h1-basic">
+
+<div id="all_box-ATL-h1-basic" class="table_wrapper">
+
+<div class="section_heading">
+  <span class="section_anchor" id="box-ATL-h1-basic_link" data-label="Atlanta Hawks (18-16)"></span><h2>Atlanta Hawks (18-16)</h2>    <div class="section_heading_text">
+      <ul>
+      </ul>
+    </div>
+
+</div>   <div class="table_outer_container">
+      <div class="overthrow table_container" id="div_box-ATL-h1-basic">
+  <table class="sortable stats_table" id="box-ATL-h1-basic" data-cols-to-freeze=1><caption>Atlanta Hawks (18-16) Table</caption>
+   <colgroup><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col></colgroup>
+   <thead>
+
+      <tr class="over_header"><th></th>
+         <th aria-label="" data-stat="header_tmp" colspan="20" class=" over_header center" >Basic Box Score Stats</th>
+      </tr>
+
+
+
+      <tr>
+         <th aria-label="Starters" data-stat="player" scope="col" class=" poptip sort_default_asc center" >Starters</th>
+         <th aria-label="Minutes Played" data-stat="mp" scope="col" class=" poptip center" data-tip="Minutes Played" data-over-header="Basic Box Score Stats" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" scope="col" class=" poptip center" data-tip="Field Goals" data-over-header="Basic Box Score Stats" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" scope="col" class=" poptip center" data-tip="Field Goal Attempts" data-over-header="Basic Box Score Stats" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" scope="col" class=" poptip center" data-tip="Field Goal Percentage" data-over-header="Basic Box Score Stats" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" scope="col" class=" poptip center" data-tip="3-Point Field Goals" data-over-header="Basic Box Score Stats" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" scope="col" class=" poptip center" data-tip="3-Point Field Goal Attempts" data-over-header="Basic Box Score Stats" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" scope="col" class=" poptip center" data-tip="3-Point Field Goal Percentage" data-over-header="Basic Box Score Stats" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" scope="col" class=" poptip center" data-tip="Free Throws" data-over-header="Basic Box Score Stats" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" scope="col" class=" poptip center" data-tip="Free Throw Attempts" data-over-header="Basic Box Score Stats" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" scope="col" class=" poptip center" data-tip="Free Throw Percentage" data-over-header="Basic Box Score Stats" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" scope="col" class=" poptip center" data-tip="Offensive Rebounds" data-over-header="Basic Box Score Stats" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" scope="col" class=" poptip center" data-tip="Defensive Rebounds" data-over-header="Basic Box Score Stats" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" scope="col" class=" poptip center" data-tip="Total Rebounds" data-over-header="Basic Box Score Stats" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" scope="col" class=" poptip center" data-tip="Assists" data-over-header="Basic Box Score Stats" >AST</th>
+         <th aria-label="Steals" data-stat="stl" scope="col" class=" poptip center" data-tip="Steals" data-over-header="Basic Box Score Stats" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" scope="col" class=" poptip center" data-tip="Blocks" data-over-header="Basic Box Score Stats" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" scope="col" class=" poptip center" data-tip="Turnovers" data-over-header="Basic Box Score Stats" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" scope="col" class=" poptip center" data-tip="Personal Fouls" data-over-header="Basic Box Score Stats" >PF</th>
+         <th aria-label="Points" data-stat="pts" scope="col" class=" poptip center" data-tip="Points" data-over-header="Basic Box Score Stats" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" scope="col" class=" poptip right" data-tip="Plus/Minus" data-over-header="Basic Box Score Stats" >+/-</th>
+      </tr>
+
+   </thead>
+   <tbody>
+<tr ><th scope="row" class="left " data-append-csv="millspa01" data-stat="player" csk="Millsap,Paul" ><a href="/players/m/millspa01.html">Paul Millsap</a></th><td class="right " data-stat="mp" csk="1065" >17:45</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >6</td><td class="right " data-stat="fg_pct" >.333</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right " data-stat="ft" >1</td><td class="right " data-stat="fta" >3</td><td class="right " data-stat="ft_pct" >.333</td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >5</td><td class="right " data-stat="trb" >5</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right " data-stat="blk" >1</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >2</td><td class="right " data-stat="pts" >5</td><td class="right " data-stat="plus_minus" >-9</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="howardw01" data-stat="player" csk="Howard,Dwight" ><a href="/players/h/howardw01.html">Dwight Howard</a></th><td class="right " data-stat="mp" csk="817" >13:37</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >4</td><td class="right " data-stat="fg_pct" >.500</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right " data-stat="ft" >2</td><td class="right " data-stat="fta" >4</td><td class="right " data-stat="ft_pct" >.500</td><td class="right " data-stat="orb" >1</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >2</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >1</td><td class="right " data-stat="pf" >2</td><td class="right " data-stat="pts" >6</td><td class="right " data-stat="plus_minus" >-10</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="schrode01" data-stat="player" csk="Schröder,Dennis" ><a href="/players/s/schrode01.html">Dennis Schröder</a></th><td class="right " data-stat="mp" csk="743" >12:23</td><td class="right " data-stat="fg" >3</td><td class="right " data-stat="fga" >6</td><td class="right " data-stat="fg_pct" >.500</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right " data-stat="orb" >1</td><td class="right iz" data-stat="drb" >0</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >3</td><td class="right iz" data-stat="stl" >0</td><td class="right " data-stat="blk" >1</td><td class="right " data-stat="tov" >1</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >6</td><td class="right " data-stat="plus_minus" >-7</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="bazemke01" data-stat="player" csk="Bazemore,Kent" ><a href="/players/b/bazemke01.html">Kent Bazemore</a></th><td class="right " data-stat="mp" csk="659" >10:59</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >5</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right " data-stat="ft" >1</td><td class="right " data-stat="fta" >2</td><td class="right " data-stat="ft_pct" >.500</td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right iz" data-stat="ast" >0</td><td class="right " data-stat="stl" >2</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >1</td><td class="right " data-stat="plus_minus" >-9</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="sefolth01" data-stat="player" csk="Sefolosha,Thabo" ><a href="/players/s/sefolth01.html">Thabo Sefolosha</a></th><td class="right " data-stat="mp" csk="708" >11:48</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >3</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right " data-stat="ft" >1</td><td class="right " data-stat="fta" >2</td><td class="right " data-stat="ft_pct" >.500</td><td class="right " data-stat="orb" >1</td><td class="right iz" data-stat="drb" >0</td><td class="right " data-stat="trb" >1</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right " data-stat="blk" >1</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >2</td><td class="right " data-stat="pts" >1</td><td class="right " data-stat="plus_minus" >-7</td></tr>
+
+      <tr class="thead">
+         <th aria-label="Reserves" data-stat="player" class=" sort_default_asc center" >Reserves</th>
+         <th aria-label="Minutes Played" data-stat="mp" class=" center" data-tip="Minutes Played" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" class=" center" data-tip="Field Goals" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" class=" center" data-tip="Field Goal Attempts" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" class=" center" data-tip="Field Goal Percentage" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" class=" center" data-tip="3-Point Field Goals" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" class=" center" data-tip="3-Point Field Goal Attempts" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" class=" center" data-tip="3-Point Field Goal Percentage" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" class=" center" data-tip="Free Throws" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" class=" center" data-tip="Free Throw Attempts" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" class=" center" data-tip="Free Throw Percentage" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" class=" center" data-tip="Offensive Rebounds" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" class=" center" data-tip="Defensive Rebounds" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" class=" center" data-tip="Total Rebounds" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" class=" center" data-tip="Assists" >AST</th>
+         <th aria-label="Steals" data-stat="stl" class=" center" data-tip="Steals" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" class=" center" data-tip="Blocks" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" class=" center" data-tip="Turnovers" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" class=" center" data-tip="Personal Fouls" >PF</th>
+         <th aria-label="Points" data-stat="pts" class=" center" data-tip="Points" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" class=" right" data-tip="Plus/Minus" >+/-</th>
+      </tr>
+
+
+<tr ><th scope="row" class="left " data-append-csv="korveky01" data-stat="player" csk="Korver,Kyle" ><a href="/players/k/korveky01.html">Kyle Korver</a></th><td class="right " data-stat="mp" csk="896" >14:56</td><td class="right " data-stat="fg" >4</td><td class="right " data-stat="fga" >7</td><td class="right " data-stat="fg_pct" >.571</td><td class="right " data-stat="fg3" >3</td><td class="right " data-stat="fg3a" >4</td><td class="right " data-stat="fg3_pct" >.750</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >3</td><td class="right " data-stat="trb" >3</td><td class="right " data-stat="ast" >1</td><td class="right " data-stat="stl" >1</td><td class="right " data-stat="blk" >1</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >11</td><td class="right " data-stat="plus_minus" >+7</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="hardati02" data-stat="player" csk="Hardaway,Tim" ><a href="/players/h/hardati02.html">Tim Hardaway</a></th><td class="right " data-stat="mp" csk="617" >10:17</td><td class="right " data-stat="fg" >3</td><td class="right " data-stat="fga" >3</td><td class="right " data-stat="fg_pct" >1.000</td><td class="right " data-stat="fg3" >2</td><td class="right " data-stat="fg3a" >2</td><td class="right " data-stat="fg3_pct" >1.000</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >2</td><td class="right " data-stat="trb" >2</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >8</td><td class="right " data-stat="plus_minus" >+5</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="delanma01" data-stat="player" csk="Delaney,Malcolm" ><a href="/players/d/delanma01.html">Malcolm Delaney</a></th><td class="right " data-stat="mp" csk="697" >11:37</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >4</td><td class="right " data-stat="fg_pct" >.500</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >3</td><td class="right " data-stat="trb" >3</td><td class="right " data-stat="ast" >2</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >2</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >4</td><td class="right " data-stat="plus_minus" >+5</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="muscami01" data-stat="player" csk="Muscala,Mike" ><a href="/players/m/muscami01.html">Mike Muscala</a></th><td class="right " data-stat="mp" csk="623" >10:23</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >3</td><td class="right " data-stat="fg_pct" >.333</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right " data-stat="ast" >1</td><td class="right " data-stat="stl" >1</td><td class="right " data-stat="blk" >1</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >2</td><td class="right " data-stat="plus_minus" >+8</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="humphkr01" data-stat="player" csk="Humphries,Kris" ><a href="/players/h/humphkr01.html">Kris Humphries</a></th><td class="right " data-stat="mp" csk="375" >6:15</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >1</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >2</td><td class="right " data-stat="trb" >2</td><td class="right iz" data-stat="ast" >0</td><td class="right " data-stat="stl" >1</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >+7</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="bembrde01" data-stat="player" csk="Bembry,DeAndre'" ><a href="/players/b/bembrde01.html">DeAndre' Bembry</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="kellyry01" data-stat="player" csk="Kelly,Ryan" ><a href="/players/k/kellyry01.html">Ryan Kelly</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+
+   </tbody>
+   <tfoot><tr ><th scope="row" class="left " data-stat="player" >Team Totals</th><td class="right " data-stat="mp" >265</td><td class="right " data-stat="fg" >42</td><td class="right " data-stat="fga" >92</td><td class="right " data-stat="fg_pct" >.457</td><td class="right " data-stat="fg3" >14</td><td class="right " data-stat="fg3a" >28</td><td class="right " data-stat="fg3_pct" >.500</td><td class="right " data-stat="ft" >16</td><td class="right " data-stat="fta" >27</td><td class="right " data-stat="ft_pct" >.593</td><td class="right " data-stat="orb" >11</td><td class="right " data-stat="drb" >35</td><td class="right " data-stat="trb" >46</td><td class="right " data-stat="ast" >25</td><td class="right " data-stat="stl" >6</td><td class="right " data-stat="blk" >6</td><td class="right " data-stat="tov" >11</td><td class="right " data-stat="pf" >21</td><td class="right " data-stat="pts" >114</td><td class="right iz" data-stat="plus_minus" ></td></tr>
+
+   </tfoot>
+
+</table>
+
+      </div>
+   </div>
+</div>
+
+
+    </div>
+
+</div>
+<div class="section_wrapper toggleable box-ATL box-ATL-q3" id="all_box-ATL-q3-basic">    <div class="section_content" id="div_box-ATL-q3-basic">
+
+<div id="all_box-ATL-q3-basic" class="table_wrapper">
+
+<div class="section_heading">
+  <span class="section_anchor" id="box-ATL-q3-basic_link" data-label="Atlanta Hawks (18-16)"></span><h2>Atlanta Hawks (18-16)</h2>    <div class="section_heading_text">
+      <ul>
+      </ul>
+    </div>
+
+</div>   <div class="table_outer_container">
+      <div class="overthrow table_container" id="div_box-ATL-q3-basic">
+  <table class="sortable stats_table" id="box-ATL-q3-basic" data-cols-to-freeze=1><caption>Atlanta Hawks (18-16) Table</caption>
+   <colgroup><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col></colgroup>
+   <thead>
+
+      <tr class="over_header"><th></th>
+         <th aria-label="" data-stat="header_tmp" colspan="20" class=" over_header center" >Basic Box Score Stats</th>
+      </tr>
+
+
+
+      <tr>
+         <th aria-label="Starters" data-stat="player" scope="col" class=" poptip sort_default_asc center" >Starters</th>
+         <th aria-label="Minutes Played" data-stat="mp" scope="col" class=" poptip center" data-tip="Minutes Played" data-over-header="Basic Box Score Stats" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" scope="col" class=" poptip center" data-tip="Field Goals" data-over-header="Basic Box Score Stats" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" scope="col" class=" poptip center" data-tip="Field Goal Attempts" data-over-header="Basic Box Score Stats" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" scope="col" class=" poptip center" data-tip="Field Goal Percentage" data-over-header="Basic Box Score Stats" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" scope="col" class=" poptip center" data-tip="3-Point Field Goals" data-over-header="Basic Box Score Stats" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" scope="col" class=" poptip center" data-tip="3-Point Field Goal Attempts" data-over-header="Basic Box Score Stats" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" scope="col" class=" poptip center" data-tip="3-Point Field Goal Percentage" data-over-header="Basic Box Score Stats" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" scope="col" class=" poptip center" data-tip="Free Throws" data-over-header="Basic Box Score Stats" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" scope="col" class=" poptip center" data-tip="Free Throw Attempts" data-over-header="Basic Box Score Stats" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" scope="col" class=" poptip center" data-tip="Free Throw Percentage" data-over-header="Basic Box Score Stats" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" scope="col" class=" poptip center" data-tip="Offensive Rebounds" data-over-header="Basic Box Score Stats" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" scope="col" class=" poptip center" data-tip="Defensive Rebounds" data-over-header="Basic Box Score Stats" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" scope="col" class=" poptip center" data-tip="Total Rebounds" data-over-header="Basic Box Score Stats" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" scope="col" class=" poptip center" data-tip="Assists" data-over-header="Basic Box Score Stats" >AST</th>
+         <th aria-label="Steals" data-stat="stl" scope="col" class=" poptip center" data-tip="Steals" data-over-header="Basic Box Score Stats" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" scope="col" class=" poptip center" data-tip="Blocks" data-over-header="Basic Box Score Stats" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" scope="col" class=" poptip center" data-tip="Turnovers" data-over-header="Basic Box Score Stats" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" scope="col" class=" poptip center" data-tip="Personal Fouls" data-over-header="Basic Box Score Stats" >PF</th>
+         <th aria-label="Points" data-stat="pts" scope="col" class=" poptip center" data-tip="Points" data-over-header="Basic Box Score Stats" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" scope="col" class=" poptip right" data-tip="Plus/Minus" data-over-header="Basic Box Score Stats" >+/-</th>
+      </tr>
+
+   </thead>
+   <tbody>
+<tr ><th scope="row" class="left " data-append-csv="millspa01" data-stat="player" csk="Millsap,Paul" ><a href="/players/m/millspa01.html">Paul Millsap</a></th><td class="right " data-stat="mp" csk="720" >12:00</td><td class="right " data-stat="fg" >4</td><td class="right " data-stat="fga" >7</td><td class="right " data-stat="fg_pct" >.571</td><td class="right " data-stat="fg3" >2</td><td class="right " data-stat="fg3a" >3</td><td class="right " data-stat="fg3_pct" >.667</td><td class="right " data-stat="ft" >2</td><td class="right " data-stat="fta" >3</td><td class="right " data-stat="ft_pct" >.667</td><td class="right " data-stat="orb" >1</td><td class="right " data-stat="drb" >3</td><td class="right " data-stat="trb" >4</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >2</td><td class="right " data-stat="pf" >2</td><td class="right " data-stat="pts" >12</td><td class="right " data-stat="plus_minus" >-3</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="howardw01" data-stat="player" csk="Howard,Dwight" ><a href="/players/h/howardw01.html">Dwight Howard</a></th><td class="right " data-stat="mp" csk="430" >7:10</td><td class="right iz" data-stat="fg" >0</td><td class="right iz" data-stat="fga" >0</td><td class="right iz" data-stat="fg_pct" ></td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right " data-stat="orb" >2</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >3</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >-1</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="schrode01" data-stat="player" csk="Schröder,Dennis" ><a href="/players/s/schrode01.html">Dennis Schröder</a></th><td class="right " data-stat="mp" csk="599" >9:59</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >4</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >2</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right " data-stat="ft" >1</td><td class="right " data-stat="fta" >1</td><td class="right " data-stat="ft_pct" >1.000</td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right " data-stat="ast" >2</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >2</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >1</td><td class="right " data-stat="plus_minus" >-6</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="bazemke01" data-stat="player" csk="Bazemore,Kent" ><a href="/players/b/bazemke01.html">Kent Bazemore</a></th><td class="right " data-stat="mp" csk="479" >7:59</td><td class="right " data-stat="fg" >3</td><td class="right " data-stat="fga" >5</td><td class="right " data-stat="fg_pct" >.600</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >1.000</td><td class="right iz" data-stat="ft" >0</td><td class="right " data-stat="fta" >2</td><td class="right " data-stat="ft_pct" >.000</td><td class="right " data-stat="orb" >1</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >2</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >7</td><td class="right " data-stat="plus_minus" >-5</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="sefolth01" data-stat="player" csk="Sefolosha,Thabo" ><a href="/players/s/sefolth01.html">Thabo Sefolosha</a></th><td class="right " data-stat="mp" csk="245" >4:05</td><td class="right iz" data-stat="fg" >0</td><td class="right iz" data-stat="fga" >0</td><td class="right iz" data-stat="fg_pct" ></td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right " data-stat="ft" >2</td><td class="right " data-stat="fta" >2</td><td class="right " data-stat="ft_pct" >1.000</td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >1</td><td class="right " data-stat="stl" >1</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >2</td><td class="right " data-stat="plus_minus" >+2</td></tr>
+
+      <tr class="thead">
+         <th aria-label="Reserves" data-stat="player" class=" sort_default_asc center" >Reserves</th>
+         <th aria-label="Minutes Played" data-stat="mp" class=" center" data-tip="Minutes Played" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" class=" center" data-tip="Field Goals" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" class=" center" data-tip="Field Goal Attempts" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" class=" center" data-tip="Field Goal Percentage" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" class=" center" data-tip="3-Point Field Goals" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" class=" center" data-tip="3-Point Field Goal Attempts" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" class=" center" data-tip="3-Point Field Goal Percentage" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" class=" center" data-tip="Free Throws" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" class=" center" data-tip="Free Throw Attempts" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" class=" center" data-tip="Free Throw Percentage" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" class=" center" data-tip="Offensive Rebounds" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" class=" center" data-tip="Defensive Rebounds" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" class=" center" data-tip="Total Rebounds" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" class=" center" data-tip="Assists" >AST</th>
+         <th aria-label="Steals" data-stat="stl" class=" center" data-tip="Steals" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" class=" center" data-tip="Blocks" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" class=" center" data-tip="Turnovers" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" class=" center" data-tip="Personal Fouls" >PF</th>
+         <th aria-label="Points" data-stat="pts" class=" center" data-tip="Points" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" class=" right" data-tip="Plus/Minus" >+/-</th>
+      </tr>
+
+
+<tr ><th scope="row" class="left " data-append-csv="korveky01" data-stat="player" csk="Korver,Kyle" ><a href="/players/k/korveky01.html">Kyle Korver</a></th><td class="right " data-stat="mp" csk="475" >7:55</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >2</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >2</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >-5</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="hardati02" data-stat="player" csk="Hardaway,Tim" ><a href="/players/h/hardati02.html">Tim Hardaway</a></th><td class="right " data-stat="mp" csk="241" >4:01</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >1</td><td class="right " data-stat="fg_pct" >1.000</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >1.000</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >3</td><td class="right " data-stat="plus_minus" >+2</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="delanma01" data-stat="player" csk="Delaney,Malcolm" ><a href="/players/d/delanma01.html">Malcolm Delaney</a></th><td class="right " data-stat="mp" csk="121" >2:01</td><td class="right iz" data-stat="fg" >0</td><td class="right iz" data-stat="fga" >0</td><td class="right iz" data-stat="fg_pct" ></td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >2</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >1</td><td class="right iz" data-stat="pf" >0</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >+3</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="muscami01" data-stat="player" csk="Muscala,Mike" ><a href="/players/m/muscami01.html">Mike Muscala</a></th><td class="right " data-stat="mp" csk="290" >4:50</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >1</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >-2</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/h/humphkr01.html'>Kris Humphries</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="bembrde01" data-stat="player" csk="Bembry,DeAndre'" ><a href="/players/b/bembrde01.html">DeAndre' Bembry</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="kellyry01" data-stat="player" csk="Kelly,Ryan" ><a href="/players/k/kellyry01.html">Ryan Kelly</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+
+   </tbody>
+   <tfoot><tr ><th scope="row" class="left " data-stat="player" >Team Totals</th><td class="right " data-stat="mp" >265</td><td class="right " data-stat="fg" >42</td><td class="right " data-stat="fga" >92</td><td class="right " data-stat="fg_pct" >.457</td><td class="right " data-stat="fg3" >14</td><td class="right " data-stat="fg3a" >28</td><td class="right " data-stat="fg3_pct" >.500</td><td class="right " data-stat="ft" >16</td><td class="right " data-stat="fta" >27</td><td class="right " data-stat="ft_pct" >.593</td><td class="right " data-stat="orb" >11</td><td class="right " data-stat="drb" >35</td><td class="right " data-stat="trb" >46</td><td class="right " data-stat="ast" >25</td><td class="right " data-stat="stl" >6</td><td class="right " data-stat="blk" >6</td><td class="right " data-stat="tov" >11</td><td class="right " data-stat="pf" >21</td><td class="right " data-stat="pts" >114</td><td class="right iz" data-stat="plus_minus" ></td></tr>
+
+   </tfoot>
+
+</table>
+
+      </div>
+   </div>
+</div>
+
+
+    </div>
+
+</div>
+<div class="section_wrapper toggleable box-ATL box-ATL-q4" id="all_box-ATL-q4-basic">    <div class="section_content" id="div_box-ATL-q4-basic">
+
+<div id="all_box-ATL-q4-basic" class="table_wrapper">
+
+<div class="section_heading">
+  <span class="section_anchor" id="box-ATL-q4-basic_link" data-label="Atlanta Hawks (18-16)"></span><h2>Atlanta Hawks (18-16)</h2>    <div class="section_heading_text">
+      <ul>
+      </ul>
+    </div>
+
+</div>   <div class="table_outer_container">
+      <div class="overthrow table_container" id="div_box-ATL-q4-basic">
+  <table class="sortable stats_table" id="box-ATL-q4-basic" data-cols-to-freeze=1><caption>Atlanta Hawks (18-16) Table</caption>
+   <colgroup><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col></colgroup>
+   <thead>
+
+      <tr class="over_header"><th></th>
+         <th aria-label="" data-stat="header_tmp" colspan="20" class=" over_header center" >Basic Box Score Stats</th>
+      </tr>
+
+
+
+      <tr>
+         <th aria-label="Starters" data-stat="player" scope="col" class=" poptip sort_default_asc center" >Starters</th>
+         <th aria-label="Minutes Played" data-stat="mp" scope="col" class=" poptip center" data-tip="Minutes Played" data-over-header="Basic Box Score Stats" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" scope="col" class=" poptip center" data-tip="Field Goals" data-over-header="Basic Box Score Stats" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" scope="col" class=" poptip center" data-tip="Field Goal Attempts" data-over-header="Basic Box Score Stats" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" scope="col" class=" poptip center" data-tip="Field Goal Percentage" data-over-header="Basic Box Score Stats" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" scope="col" class=" poptip center" data-tip="3-Point Field Goals" data-over-header="Basic Box Score Stats" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" scope="col" class=" poptip center" data-tip="3-Point Field Goal Attempts" data-over-header="Basic Box Score Stats" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" scope="col" class=" poptip center" data-tip="3-Point Field Goal Percentage" data-over-header="Basic Box Score Stats" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" scope="col" class=" poptip center" data-tip="Free Throws" data-over-header="Basic Box Score Stats" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" scope="col" class=" poptip center" data-tip="Free Throw Attempts" data-over-header="Basic Box Score Stats" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" scope="col" class=" poptip center" data-tip="Free Throw Percentage" data-over-header="Basic Box Score Stats" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" scope="col" class=" poptip center" data-tip="Offensive Rebounds" data-over-header="Basic Box Score Stats" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" scope="col" class=" poptip center" data-tip="Defensive Rebounds" data-over-header="Basic Box Score Stats" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" scope="col" class=" poptip center" data-tip="Total Rebounds" data-over-header="Basic Box Score Stats" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" scope="col" class=" poptip center" data-tip="Assists" data-over-header="Basic Box Score Stats" >AST</th>
+         <th aria-label="Steals" data-stat="stl" scope="col" class=" poptip center" data-tip="Steals" data-over-header="Basic Box Score Stats" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" scope="col" class=" poptip center" data-tip="Blocks" data-over-header="Basic Box Score Stats" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" scope="col" class=" poptip center" data-tip="Turnovers" data-over-header="Basic Box Score Stats" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" scope="col" class=" poptip center" data-tip="Personal Fouls" data-over-header="Basic Box Score Stats" >PF</th>
+         <th aria-label="Points" data-stat="pts" scope="col" class=" poptip center" data-tip="Points" data-over-header="Basic Box Score Stats" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" scope="col" class=" poptip right" data-tip="Plus/Minus" data-over-header="Basic Box Score Stats" >+/-</th>
+      </tr>
+
+   </thead>
+   <tbody>
+<tr ><th scope="row" class="left " data-append-csv="millspa01" data-stat="player" csk="Millsap,Paul" ><a href="/players/m/millspa01.html">Paul Millsap</a></th><td class="right " data-stat="mp" csk="720" >12:00</td><td class="right " data-stat="fg" >5</td><td class="right " data-stat="fga" >7</td><td class="right " data-stat="fg_pct" >.714</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >2</td><td class="right " data-stat="fg3_pct" >.500</td><td class="right " data-stat="ft" >4</td><td class="right " data-stat="fta" >4</td><td class="right " data-stat="ft_pct" >1.000</td><td class="right " data-stat="orb" >1</td><td class="right " data-stat="drb" >2</td><td class="right " data-stat="trb" >3</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >15</td><td class="right " data-stat="plus_minus" >+5</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="howardw01" data-stat="player" csk="Howard,Dwight" ><a href="/players/h/howardw01.html">Dwight Howard</a></th><td class="right " data-stat="mp" csk="542" >9:02</td><td class="right iz" data-stat="fg" >0</td><td class="right iz" data-stat="fga" >0</td><td class="right iz" data-stat="fg_pct" ></td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >+4</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="schrode01" data-stat="player" csk="Schröder,Dennis" ><a href="/players/s/schrode01.html">Dennis Schröder</a></th><td class="right " data-stat="mp" csk="363" >6:03</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >4</td><td class="right " data-stat="fg_pct" >.500</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right " data-stat="ast" >3</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >4</td><td class="right " data-stat="plus_minus" >+4</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="bazemke01" data-stat="player" csk="Bazemore,Kent" ><a href="/players/b/bazemke01.html">Kent Bazemore</a></th><td class="right " data-stat="mp" csk="4" >0:04</td><td class="right iz" data-stat="fg" >0</td><td class="right iz" data-stat="fga" >0</td><td class="right iz" data-stat="fg_pct" ></td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >-2</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="sefolth01" data-stat="player" csk="Sefolosha,Thabo" ><a href="/players/s/sefolth01.html">Thabo Sefolosha</a></th><td class="right " data-stat="mp" csk="4" >0:04</td><td class="right iz" data-stat="fg" >0</td><td class="right iz" data-stat="fga" >0</td><td class="right iz" data-stat="fg_pct" ></td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >-2</td></tr>
+
+      <tr class="thead">
+         <th aria-label="Reserves" data-stat="player" class=" sort_default_asc center" >Reserves</th>
+         <th aria-label="Minutes Played" data-stat="mp" class=" center" data-tip="Minutes Played" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" class=" center" data-tip="Field Goals" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" class=" center" data-tip="Field Goal Attempts" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" class=" center" data-tip="Field Goal Percentage" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" class=" center" data-tip="3-Point Field Goals" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" class=" center" data-tip="3-Point Field Goal Attempts" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" class=" center" data-tip="3-Point Field Goal Percentage" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" class=" center" data-tip="Free Throws" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" class=" center" data-tip="Free Throw Attempts" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" class=" center" data-tip="Free Throw Percentage" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" class=" center" data-tip="Offensive Rebounds" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" class=" center" data-tip="Defensive Rebounds" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" class=" center" data-tip="Total Rebounds" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" class=" center" data-tip="Assists" >AST</th>
+         <th aria-label="Steals" data-stat="stl" class=" center" data-tip="Steals" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" class=" center" data-tip="Blocks" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" class=" center" data-tip="Turnovers" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" class=" center" data-tip="Personal Fouls" >PF</th>
+         <th aria-label="Points" data-stat="pts" class=" center" data-tip="Points" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" class=" right" data-tip="Plus/Minus" >+/-</th>
+      </tr>
+
+
+<tr ><th scope="row" class="left " data-append-csv="korveky01" data-stat="player" csk="Korver,Kyle" ><a href="/players/k/korveky01.html">Kyle Korver</a></th><td class="right " data-stat="mp" csk="716" >11:56</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >2</td><td class="right " data-stat="fg_pct" >.500</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >2</td><td class="right " data-stat="fg3_pct" >.500</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >3</td><td class="right " data-stat="trb" >3</td><td class="right " data-stat="ast" >2</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >3</td><td class="right " data-stat="plus_minus" >+7</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="hardati02" data-stat="player" csk="Hardaway,Tim" ><a href="/players/h/hardati02.html">Tim Hardaway</a></th><td class="right " data-stat="mp" csk="720" >12:00</td><td class="right " data-stat="fg" >4</td><td class="right " data-stat="fga" >6</td><td class="right " data-stat="fg_pct" >.667</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >2</td><td class="right " data-stat="fg3_pct" >.500</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >1</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >9</td><td class="right " data-stat="plus_minus" >+5</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="delanma01" data-stat="player" csk="Delaney,Malcolm" ><a href="/players/d/delanma01.html">Malcolm Delaney</a></th><td class="right " data-stat="mp" csk="357" >5:57</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >1</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >+1</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="muscami01" data-stat="player" csk="Muscala,Mike" ><a href="/players/m/muscami01.html">Mike Muscala</a></th><td class="right " data-stat="mp" csk="174" >2:54</td><td class="right iz" data-stat="fg" >0</td><td class="right iz" data-stat="fga" >0</td><td class="right iz" data-stat="fg_pct" ></td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >+3</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/h/humphkr01.html'>Kris Humphries</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="bembrde01" data-stat="player" csk="Bembry,DeAndre'" ><a href="/players/b/bembrde01.html">DeAndre' Bembry</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="kellyry01" data-stat="player" csk="Kelly,Ryan" ><a href="/players/k/kellyry01.html">Ryan Kelly</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+
+   </tbody>
+   <tfoot><tr ><th scope="row" class="left " data-stat="player" >Team Totals</th><td class="right " data-stat="mp" >265</td><td class="right " data-stat="fg" >42</td><td class="right " data-stat="fga" >92</td><td class="right " data-stat="fg_pct" >.457</td><td class="right " data-stat="fg3" >14</td><td class="right " data-stat="fg3a" >28</td><td class="right " data-stat="fg3_pct" >.500</td><td class="right " data-stat="ft" >16</td><td class="right " data-stat="fta" >27</td><td class="right " data-stat="ft_pct" >.593</td><td class="right " data-stat="orb" >11</td><td class="right " data-stat="drb" >35</td><td class="right " data-stat="trb" >46</td><td class="right " data-stat="ast" >25</td><td class="right " data-stat="stl" >6</td><td class="right " data-stat="blk" >6</td><td class="right " data-stat="tov" >11</td><td class="right " data-stat="pf" >21</td><td class="right " data-stat="pts" >114</td><td class="right iz" data-stat="plus_minus" ></td></tr>
+
+   </tfoot>
+
+</table>
+
+      </div>
+   </div>
+</div>
+
+
+    </div>
+
+</div>
+<div class="section_wrapper toggleable box-ATL box-ATL-h2" id="all_box-ATL-h2-basic">    <div class="section_content" id="div_box-ATL-h2-basic">
+
+<div id="all_box-ATL-h2-basic" class="table_wrapper">
+
+<div class="section_heading">
+  <span class="section_anchor" id="box-ATL-h2-basic_link" data-label="Atlanta Hawks (18-16)"></span><h2>Atlanta Hawks (18-16)</h2>    <div class="section_heading_text">
+      <ul>
+      </ul>
+    </div>
+
+</div>   <div class="table_outer_container">
+      <div class="overthrow table_container" id="div_box-ATL-h2-basic">
+  <table class="sortable stats_table" id="box-ATL-h2-basic" data-cols-to-freeze=1><caption>Atlanta Hawks (18-16) Table</caption>
+   <colgroup><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col></colgroup>
+   <thead>
+
+      <tr class="over_header"><th></th>
+         <th aria-label="" data-stat="header_tmp" colspan="20" class=" over_header center" >Basic Box Score Stats</th>
+      </tr>
+
+
+
+      <tr>
+         <th aria-label="Starters" data-stat="player" scope="col" class=" poptip sort_default_asc center" >Starters</th>
+         <th aria-label="Minutes Played" data-stat="mp" scope="col" class=" poptip center" data-tip="Minutes Played" data-over-header="Basic Box Score Stats" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" scope="col" class=" poptip center" data-tip="Field Goals" data-over-header="Basic Box Score Stats" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" scope="col" class=" poptip center" data-tip="Field Goal Attempts" data-over-header="Basic Box Score Stats" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" scope="col" class=" poptip center" data-tip="Field Goal Percentage" data-over-header="Basic Box Score Stats" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" scope="col" class=" poptip center" data-tip="3-Point Field Goals" data-over-header="Basic Box Score Stats" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" scope="col" class=" poptip center" data-tip="3-Point Field Goal Attempts" data-over-header="Basic Box Score Stats" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" scope="col" class=" poptip center" data-tip="3-Point Field Goal Percentage" data-over-header="Basic Box Score Stats" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" scope="col" class=" poptip center" data-tip="Free Throws" data-over-header="Basic Box Score Stats" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" scope="col" class=" poptip center" data-tip="Free Throw Attempts" data-over-header="Basic Box Score Stats" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" scope="col" class=" poptip center" data-tip="Free Throw Percentage" data-over-header="Basic Box Score Stats" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" scope="col" class=" poptip center" data-tip="Offensive Rebounds" data-over-header="Basic Box Score Stats" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" scope="col" class=" poptip center" data-tip="Defensive Rebounds" data-over-header="Basic Box Score Stats" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" scope="col" class=" poptip center" data-tip="Total Rebounds" data-over-header="Basic Box Score Stats" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" scope="col" class=" poptip center" data-tip="Assists" data-over-header="Basic Box Score Stats" >AST</th>
+         <th aria-label="Steals" data-stat="stl" scope="col" class=" poptip center" data-tip="Steals" data-over-header="Basic Box Score Stats" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" scope="col" class=" poptip center" data-tip="Blocks" data-over-header="Basic Box Score Stats" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" scope="col" class=" poptip center" data-tip="Turnovers" data-over-header="Basic Box Score Stats" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" scope="col" class=" poptip center" data-tip="Personal Fouls" data-over-header="Basic Box Score Stats" >PF</th>
+         <th aria-label="Points" data-stat="pts" scope="col" class=" poptip center" data-tip="Points" data-over-header="Basic Box Score Stats" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" scope="col" class=" poptip right" data-tip="Plus/Minus" data-over-header="Basic Box Score Stats" >+/-</th>
+      </tr>
+
+   </thead>
+   <tbody>
+<tr ><th scope="row" class="left " data-append-csv="millspa01" data-stat="player" csk="Millsap,Paul" ><a href="/players/m/millspa01.html">Paul Millsap</a></th><td class="right " data-stat="mp" csk="1440" >24:00</td><td class="right " data-stat="fg" >9</td><td class="right " data-stat="fga" >14</td><td class="right " data-stat="fg_pct" >.643</td><td class="right " data-stat="fg3" >3</td><td class="right " data-stat="fg3a" >5</td><td class="right " data-stat="fg3_pct" >.600</td><td class="right " data-stat="ft" >6</td><td class="right " data-stat="fta" >7</td><td class="right " data-stat="ft_pct" >.857</td><td class="right " data-stat="orb" >2</td><td class="right " data-stat="drb" >5</td><td class="right " data-stat="trb" >7</td><td class="right " data-stat="ast" >2</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >2</td><td class="right " data-stat="pf" >3</td><td class="right " data-stat="pts" >27</td><td class="right " data-stat="plus_minus" >+2</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="howardw01" data-stat="player" csk="Howard,Dwight" ><a href="/players/h/howardw01.html">Dwight Howard</a></th><td class="right " data-stat="mp" csk="972" >16:12</td><td class="right iz" data-stat="fg" >0</td><td class="right iz" data-stat="fga" >0</td><td class="right iz" data-stat="fg_pct" ></td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right " data-stat="orb" >2</td><td class="right " data-stat="drb" >2</td><td class="right " data-stat="trb" >4</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >+3</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="schrode01" data-stat="player" csk="Schröder,Dennis" ><a href="/players/s/schrode01.html">Dennis Schröder</a></th><td class="right " data-stat="mp" csk="962" >16:02</td><td class="right " data-stat="fg" >2</td><td class="right " data-stat="fga" >8</td><td class="right " data-stat="fg_pct" >.250</td><td class="right iz" data-stat="fg3" >0</td><td class="right " data-stat="fg3a" >2</td><td class="right " data-stat="fg3_pct" >.000</td><td class="right " data-stat="ft" >1</td><td class="right " data-stat="fta" >1</td><td class="right " data-stat="ft_pct" >1.000</td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right " data-stat="ast" >5</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >2</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >5</td><td class="right " data-stat="plus_minus" >-2</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="bazemke01" data-stat="player" csk="Bazemore,Kent" ><a href="/players/b/bazemke01.html">Kent Bazemore</a></th><td class="right " data-stat="mp" csk="483" >8:03</td><td class="right " data-stat="fg" >3</td><td class="right " data-stat="fga" >5</td><td class="right " data-stat="fg_pct" >.600</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >1</td><td class="right " data-stat="fg3_pct" >1.000</td><td class="right iz" data-stat="ft" >0</td><td class="right " data-stat="fta" >2</td><td class="right " data-stat="ft_pct" >.000</td><td class="right " data-stat="orb" >1</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >2</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >2</td><td class="right " data-stat="pts" >7</td><td class="right " data-stat="plus_minus" >-7</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="sefolth01" data-stat="player" csk="Sefolosha,Thabo" ><a href="/players/s/sefolth01.html">Thabo Sefolosha</a></th><td class="right " data-stat="mp" csk="249" >4:09</td><td class="right iz" data-stat="fg" >0</td><td class="right iz" data-stat="fga" >0</td><td class="right iz" data-stat="fg_pct" ></td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right " data-stat="ft" >2</td><td class="right " data-stat="fta" >2</td><td class="right " data-stat="ft_pct" >1.000</td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >1</td><td class="right " data-stat="stl" >1</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >1</td><td class="right " data-stat="pts" >2</td><td class="right iz" data-stat="plus_minus" >0</td></tr>
+
+      <tr class="thead">
+         <th aria-label="Reserves" data-stat="player" class=" sort_default_asc center" >Reserves</th>
+         <th aria-label="Minutes Played" data-stat="mp" class=" center" data-tip="Minutes Played" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" class=" center" data-tip="Field Goals" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" class=" center" data-tip="Field Goal Attempts" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" class=" center" data-tip="Field Goal Percentage" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" class=" center" data-tip="3-Point Field Goals" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" class=" center" data-tip="3-Point Field Goal Attempts" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" class=" center" data-tip="3-Point Field Goal Percentage" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" class=" center" data-tip="Free Throws" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" class=" center" data-tip="Free Throw Attempts" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" class=" center" data-tip="Free Throw Percentage" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" class=" center" data-tip="Offensive Rebounds" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" class=" center" data-tip="Defensive Rebounds" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" class=" center" data-tip="Total Rebounds" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" class=" center" data-tip="Assists" >AST</th>
+         <th aria-label="Steals" data-stat="stl" class=" center" data-tip="Steals" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" class=" center" data-tip="Blocks" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" class=" center" data-tip="Turnovers" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" class=" center" data-tip="Personal Fouls" >PF</th>
+         <th aria-label="Points" data-stat="pts" class=" center" data-tip="Points" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" class=" right" data-tip="Plus/Minus" >+/-</th>
+      </tr>
+
+
+<tr ><th scope="row" class="left " data-append-csv="korveky01" data-stat="player" csk="Korver,Kyle" ><a href="/players/k/korveky01.html">Kyle Korver</a></th><td class="right " data-stat="mp" csk="1191" >19:51</td><td class="right " data-stat="fg" >1</td><td class="right " data-stat="fga" >4</td><td class="right " data-stat="fg_pct" >.250</td><td class="right " data-stat="fg3" >1</td><td class="right " data-stat="fg3a" >4</td><td class="right " data-stat="fg3_pct" >.250</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >4</td><td class="right " data-stat="trb" >4</td><td class="right " data-stat="ast" >2</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >3</td><td class="right " data-stat="plus_minus" >+2</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="hardati02" data-stat="player" csk="Hardaway,Tim" ><a href="/players/h/hardati02.html">Tim Hardaway</a></th><td class="right " data-stat="mp" csk="961" >16:01</td><td class="right " data-stat="fg" >5</td><td class="right " data-stat="fga" >7</td><td class="right " data-stat="fg_pct" >.714</td><td class="right " data-stat="fg3" >2</td><td class="right " data-stat="fg3a" >3</td><td class="right " data-stat="fg3_pct" >.667</td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right iz" data-stat="drb" >0</td><td class="right iz" data-stat="trb" >0</td><td class="right " data-stat="ast" >1</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >1</td><td class="right iz" data-stat="pf" >0</td><td class="right " data-stat="pts" >12</td><td class="right " data-stat="plus_minus" >+7</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="delanma01" data-stat="player" csk="Delaney,Malcolm" ><a href="/players/d/delanma01.html">Malcolm Delaney</a></th><td class="right " data-stat="mp" csk="478" >7:58</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >1</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right " data-stat="ast" >2</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right " data-stat="tov" >1</td><td class="right iz" data-stat="pf" >0</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >+4</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="muscami01" data-stat="player" csk="Muscala,Mike" ><a href="/players/m/muscami01.html">Mike Muscala</a></th><td class="right " data-stat="mp" csk="464" >7:44</td><td class="right iz" data-stat="fg" >0</td><td class="right " data-stat="fga" >1</td><td class="right " data-stat="fg_pct" >.000</td><td class="right iz" data-stat="fg3" >0</td><td class="right iz" data-stat="fg3a" >0</td><td class="right iz" data-stat="fg3_pct" ></td><td class="right iz" data-stat="ft" >0</td><td class="right iz" data-stat="fta" >0</td><td class="right iz" data-stat="ft_pct" ></td><td class="right iz" data-stat="orb" >0</td><td class="right " data-stat="drb" >1</td><td class="right " data-stat="trb" >1</td><td class="right iz" data-stat="ast" >0</td><td class="right iz" data-stat="stl" >0</td><td class="right iz" data-stat="blk" >0</td><td class="right iz" data-stat="tov" >0</td><td class="right " data-stat="pf" >2</td><td class="right iz" data-stat="pts" >0</td><td class="right " data-stat="plus_minus" >+1</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/h/humphkr01.html'>Kris Humphries</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="bembrde01" data-stat="player" csk="Bembry,DeAndre'" ><a href="/players/b/bembrde01.html">DeAndre' Bembry</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="kellyry01" data-stat="player" csk="Kelly,Ryan" ><a href="/players/k/kellyry01.html">Ryan Kelly</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+
+   </tbody>
+   <tfoot><tr ><th scope="row" class="left " data-stat="player" >Team Totals</th><td class="right " data-stat="mp" >265</td><td class="right " data-stat="fg" >42</td><td class="right " data-stat="fga" >92</td><td class="right " data-stat="fg_pct" >.457</td><td class="right " data-stat="fg3" >14</td><td class="right " data-stat="fg3a" >28</td><td class="right " data-stat="fg3_pct" >.500</td><td class="right " data-stat="ft" >16</td><td class="right " data-stat="fta" >27</td><td class="right " data-stat="ft_pct" >.593</td><td class="right " data-stat="orb" >11</td><td class="right " data-stat="drb" >35</td><td class="right " data-stat="trb" >46</td><td class="right " data-stat="ast" >25</td><td class="right " data-stat="stl" >6</td><td class="right " data-stat="blk" >6</td><td class="right " data-stat="tov" >11</td><td class="right " data-stat="pf" >21</td><td class="right " data-stat="pts" >114</td><td class="right iz" data-stat="plus_minus" ></td></tr>
+
+   </tfoot>
+
+</table>
+
+      </div>
+   </div>
+</div>
+
+
+    </div>
+
+</div>
+<div class="section_wrapper toggleable box-ATL box-ATL-q5" id="all_box-ATL-q5-basic">    <div class="section_content" id="div_box-ATL-q5-basic">
+
+<div id="all_box-ATL-q5-basic" class="table_wrapper">
+
+<div class="section_heading">
+  <span class="section_anchor" id="box-ATL-q5-basic_link" data-label="Atlanta Hawks (18-16)"></span><h2>Atlanta Hawks (18-16)</h2>    <div class="section_heading_text">
+      <ul>
+      </ul>
+    </div>
+
+</div>   <div class="table_outer_container">
+      <div class="overthrow table_container" id="div_box-ATL-q5-basic">
+  <table class="sortable stats_table" id="box-ATL-q5-basic" data-cols-to-freeze=1><caption>Atlanta Hawks (18-16) Table</caption>
+   <colgroup><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col></colgroup>
+   <thead>
+
+      <tr class="over_header"><th></th>
+         <th aria-label="" data-stat="header_tmp" colspan="20" class=" over_header center" >Basic Box Score Stats</th>
+      </tr>
+
+
+
+      <tr>
+         <th aria-label="Starters" data-stat="player" scope="col" class=" poptip sort_default_asc center" >Starters</th>
+         <th aria-label="Minutes Played" data-stat="mp" scope="col" class=" poptip center" data-tip="Minutes Played" data-over-header="Basic Box Score Stats" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" scope="col" class=" poptip center" data-tip="Field Goals" data-over-header="Basic Box Score Stats" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" scope="col" class=" poptip center" data-tip="Field Goal Attempts" data-over-header="Basic Box Score Stats" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" scope="col" class=" poptip center" data-tip="Field Goal Percentage" data-over-header="Basic Box Score Stats" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" scope="col" class=" poptip center" data-tip="3-Point Field Goals" data-over-header="Basic Box Score Stats" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" scope="col" class=" poptip center" data-tip="3-Point Field Goal Attempts" data-over-header="Basic Box Score Stats" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" scope="col" class=" poptip center" data-tip="3-Point Field Goal Percentage" data-over-header="Basic Box Score Stats" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" scope="col" class=" poptip center" data-tip="Free Throws" data-over-header="Basic Box Score Stats" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" scope="col" class=" poptip center" data-tip="Free Throw Attempts" data-over-header="Basic Box Score Stats" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" scope="col" class=" poptip center" data-tip="Free Throw Percentage" data-over-header="Basic Box Score Stats" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" scope="col" class=" poptip center" data-tip="Offensive Rebounds" data-over-header="Basic Box Score Stats" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" scope="col" class=" poptip center" data-tip="Defensive Rebounds" data-over-header="Basic Box Score Stats" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" scope="col" class=" poptip center" data-tip="Total Rebounds" data-over-header="Basic Box Score Stats" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" scope="col" class=" poptip center" data-tip="Assists" data-over-header="Basic Box Score Stats" >AST</th>
+         <th aria-label="Steals" data-stat="stl" scope="col" class=" poptip center" data-tip="Steals" data-over-header="Basic Box Score Stats" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" scope="col" class=" poptip center" data-tip="Blocks" data-over-header="Basic Box Score Stats" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" scope="col" class=" poptip center" data-tip="Turnovers" data-over-header="Basic Box Score Stats" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" scope="col" class=" poptip center" data-tip="Personal Fouls" data-over-header="Basic Box Score Stats" >PF</th>
+         <th aria-label="Points" data-stat="pts" scope="col" class=" poptip center" data-tip="Points" data-over-header="Basic Box Score Stats" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" scope="col" class=" poptip right" data-tip="Plus/Minus" data-over-header="Basic Box Score Stats" >+/-</th>
+      </tr>
+
+   </thead>
+   <tbody>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/m/millspa01.html'>Paul Millsap</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/h/howardw01.html'>Dwight Howard</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/s/schrode01.html'>Dennis Schröder</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/b/bazemke01.html'>Kent Bazemore</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/s/sefolth01.html'>Thabo Sefolosha</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+
+      <tr class="thead">
+         <th aria-label="Reserves" data-stat="player" class=" sort_default_asc center" >Reserves</th>
+         <th aria-label="Minutes Played" data-stat="mp" class=" center" data-tip="Minutes Played" >MP</th>
+         <th aria-label="Field Goals" data-stat="fg" class=" center" data-tip="Field Goals" >FG</th>
+         <th aria-label="Field Goal Attempts" data-stat="fga" class=" center" data-tip="Field Goal Attempts" >FGA</th>
+         <th aria-label="Field Goal Percentage" data-stat="fg_pct" class=" center" data-tip="Field Goal Percentage" >FG%</th>
+         <th aria-label="3-Point Field Goals" data-stat="fg3" class=" center" data-tip="3-Point Field Goals" >3P</th>
+         <th aria-label="3-Point Field Goal Attempts" data-stat="fg3a" class=" center" data-tip="3-Point Field Goal Attempts" >3PA</th>
+         <th aria-label="3-Point Field Goal Percentage" data-stat="fg3_pct" class=" center" data-tip="3-Point Field Goal Percentage" >3P%</th>
+         <th aria-label="Free Throws" data-stat="ft" class=" center" data-tip="Free Throws" >FT</th>
+         <th aria-label="Free Throw Attempts" data-stat="fta" class=" center" data-tip="Free Throw Attempts" >FTA</th>
+         <th aria-label="Free Throw Percentage" data-stat="ft_pct" class=" center" data-tip="Free Throw Percentage" >FT%</th>
+         <th aria-label="Offensive Rebounds" data-stat="orb" class=" center" data-tip="Offensive Rebounds" >ORB</th>
+         <th aria-label="Defensive Rebounds" data-stat="drb" class=" center" data-tip="Defensive Rebounds" >DRB</th>
+         <th aria-label="Total Rebounds" data-stat="trb" class=" center" data-tip="Total Rebounds" >TRB</th>
+         <th aria-label="Assists" data-stat="ast" class=" center" data-tip="Assists" >AST</th>
+         <th aria-label="Steals" data-stat="stl" class=" center" data-tip="Steals" >STL</th>
+         <th aria-label="Blocks" data-stat="blk" class=" center" data-tip="Blocks" >BLK</th>
+         <th aria-label="Turnovers" data-stat="tov" class=" center" data-tip="Turnovers" >TOV</th>
+         <th aria-label="Personal Fouls" data-stat="pf" class=" center" data-tip="Personal Fouls" >PF</th>
+         <th aria-label="Points" data-stat="pts" class=" center" data-tip="Points" >PTS</th>
+         <th aria-label="Plus/Minus" data-stat="plus_minus" class=" right" data-tip="Plus/Minus" >+/-</th>
+      </tr>
+
+
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/k/korveky01.html'>Kyle Korver</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/h/hardati02.html'>Tim Hardaway</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/d/delanma01.html'>Malcolm Delaney</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/m/muscami01.html'>Mike Muscala</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-stat="player" ><a href='/players/h/humphkr01.html'>Kris Humphries</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >&nbsp;</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="bembrde01" data-stat="player" csk="Bembry,DeAndre'" ><a href="/players/b/bembrde01.html">DeAndre' Bembry</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="kellyry01" data-stat="player" csk="Kelly,Ryan" ><a href="/players/k/kellyry01.html">Ryan Kelly</a></th><td class="center " data-stat="reason" colspan=20 class='italic_text gray_text' >Did Not Play</td></tr>
+
+   </tbody>
+   <tfoot><tr ><th scope="row" class="left " data-stat="player" >Team Totals</th><td class="right " data-stat="mp" >265</td><td class="right " data-stat="fg" >42</td><td class="right " data-stat="fga" >92</td><td class="right " data-stat="fg_pct" >.457</td><td class="right " data-stat="fg3" >14</td><td class="right " data-stat="fg3a" >28</td><td class="right " data-stat="fg3_pct" >.500</td><td class="right " data-stat="ft" >16</td><td class="right " data-stat="fta" >27</td><td class="right " data-stat="ft_pct" >.593</td><td class="right " data-stat="orb" >11</td><td class="right " data-stat="drb" >35</td><td class="right " data-stat="trb" >46</td><td class="right " data-stat="ast" >25</td><td class="right " data-stat="stl" >6</td><td class="right " data-stat="blk" >6</td><td class="right " data-stat="tov" >11</td><td class="right " data-stat="pf" >21</td><td class="right " data-stat="pts" >114</td><td class="right iz" data-stat="plus_minus" ></td></tr>
+
+   </tfoot>
+
+</table>
+
+      </div>
+   </div>
+</div>
+
+
+    </div>
+
+</div>
+<div class="section_wrapper box-ATL box-ATL-game" id="all_box-ATL-game-advanced">    <div class="section_content" id="div_box-ATL-game-advanced">
+
+<div id="all_box-ATL-game-advanced" class="table_wrapper">
+
+<div class="section_heading">
+  <span class="section_anchor" id="box-ATL-game-advanced_link" data-label=""></span><h2></h2>    <div class="section_heading_text">
+      <ul>
+      </ul>
+    </div>
+
+</div>   <div class="table_outer_container">
+      <div class="overthrow table_container" id="div_box-ATL-game-advanced">
+  <table class="sortable stats_table" id="box-ATL-game-advanced" data-cols-to-freeze=1><caption> Table</caption>
    <colgroup><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col><col></colgroup>
    <thead>
 
@@ -930,7 +2479,7 @@ sr_menus_setupMainNav_button_inline();
    <tbody>
 <tr ><th scope="row" class="left " data-append-csv="millspa01" data-stat="player" csk="Millsap,Paul" ><a href="/players/m/millspa01.html">Paul Millsap</a></th><td class="right " data-stat="mp" csk="2805" >46:45</td><td class="right " data-stat="ts_pct" >.584</td><td class="right " data-stat="efg_pct" >.543</td><td class="right " data-stat="fg3a_per_fga_pct" >.261</td><td class="right " data-stat="fta_per_fga_pct" >.435</td><td class="right " data-stat="orb_pct" >6.9</td><td class="right " data-stat="drb_pct" >25.8</td><td class="right " data-stat="trb_pct" >15.8</td><td class="right " data-stat="ast_pct" >11.5</td><td class="right " data-stat="stl_pct" >0.0</td><td class="right " data-stat="blk_pct" >1.8</td><td class="right " data-stat="tov_pct" >6.8</td><td class="right " data-stat="usg_pct" >29.0</td><td class="right " data-stat="off_rtg" >119</td><td class="right " data-stat="def_rtg" >112</td></tr>
 <tr ><th scope="row" class="left " data-append-csv="howardw01" data-stat="player" csk="Howard,Dwight" ><a href="/players/h/howardw01.html">Dwight Howard</a></th><td class="right " data-stat="mp" csk="2057" >34:17</td><td class="right " data-stat="ts_pct" >.521</td><td class="right " data-stat="efg_pct" >.500</td><td class="right " data-stat="fg3a_per_fga_pct" >.000</td><td class="right " data-stat="fta_per_fga_pct" >1.000</td><td class="right " data-stat="orb_pct" >12.6</td><td class="right " data-stat="drb_pct" >14.1</td><td class="right " data-stat="trb_pct" >13.3</td><td class="right " data-stat="ast_pct" >4.0</td><td class="right " data-stat="stl_pct" >0.0</td><td class="right " data-stat="blk_pct" >2.5</td><td class="right " data-stat="tov_pct" >25.8</td><td class="right " data-stat="usg_pct" >10.4</td><td class="right " data-stat="off_rtg" >104</td><td class="right " data-stat="def_rtg" >114</td></tr>
-<tr ><th scope="row" class="left " data-append-csv="schrode01" data-stat="player" csk="Schroder,Dennis" ><a href="/players/s/schrode01.html">Dennis Schroder</a></th><td class="right " data-stat="mp" csk="2005" >33:25</td><td class="right " data-stat="ts_pct" >.437</td><td class="right " data-stat="efg_pct" >.412</td><td class="right " data-stat="fg3a_per_fga_pct" >.118</td><td class="right " data-stat="fta_per_fga_pct" >.176</td><td class="right " data-stat="orb_pct" >3.2</td><td class="right " data-stat="drb_pct" >0.0</td><td class="right " data-stat="trb_pct" >1.7</td><td class="right " data-stat="ast_pct" >51.3</td><td class="right " data-stat="stl_pct" >0.0</td><td class="right " data-stat="blk_pct" >2.5</td><td class="right " data-stat="tov_pct" >14.1</td><td class="right " data-stat="usg_pct" >29.4</td><td class="right " data-stat="off_rtg" >101</td><td class="right " data-stat="def_rtg" >117</td></tr>
+<tr ><th scope="row" class="left " data-append-csv="schrode01" data-stat="player" csk="Schröder,Dennis" ><a href="/players/s/schrode01.html">Dennis Schröder</a></th><td class="right " data-stat="mp" csk="2005" >33:25</td><td class="right " data-stat="ts_pct" >.437</td><td class="right " data-stat="efg_pct" >.412</td><td class="right " data-stat="fg3a_per_fga_pct" >.118</td><td class="right " data-stat="fta_per_fga_pct" >.176</td><td class="right " data-stat="orb_pct" >3.2</td><td class="right " data-stat="drb_pct" >0.0</td><td class="right " data-stat="trb_pct" >1.7</td><td class="right " data-stat="ast_pct" >51.3</td><td class="right " data-stat="stl_pct" >0.0</td><td class="right " data-stat="blk_pct" >2.5</td><td class="right " data-stat="tov_pct" >14.1</td><td class="right " data-stat="usg_pct" >29.4</td><td class="right " data-stat="off_rtg" >101</td><td class="right " data-stat="def_rtg" >117</td></tr>
 <tr ><th scope="row" class="left " data-append-csv="bazemke01" data-stat="player" csk="Bazemore,Kent" ><a href="/players/b/bazemke01.html">Kent Bazemore</a></th><td class="right " data-stat="mp" csk="1146" >19:06</td><td class="right " data-stat="ts_pct" >.340</td><td class="right " data-stat="efg_pct" >.350</td><td class="right " data-stat="fg3a_per_fga_pct" >.200</td><td class="right " data-stat="fta_per_fga_pct" >.400</td><td class="right " data-stat="orb_pct" >5.7</td><td class="right " data-stat="drb_pct" >6.3</td><td class="right " data-stat="trb_pct" >6.0</td><td class="right " data-stat="ast_pct" >0.0</td><td class="right " data-stat="stl_pct" >5.5</td><td class="right " data-stat="blk_pct" >0.0</td><td class="right " data-stat="tov_pct" >0.0</td><td class="right " data-stat="usg_pct" >28.4</td><td class="right " data-stat="off_rtg" >76</td><td class="right " data-stat="def_rtg" >105</td></tr>
 <tr ><th scope="row" class="left " data-append-csv="sefolth01" data-stat="player" csk="Sefolosha,Thabo" ><a href="/players/s/sefolth01.html">Thabo Sefolosha</a></th><td class="right " data-stat="mp" csk="979" >16:19</td><td class="right " data-stat="ts_pct" >.315</td><td class="right " data-stat="efg_pct" >.000</td><td class="right " data-stat="fg3a_per_fga_pct" >.333</td><td class="right " data-stat="fta_per_fga_pct" >1.333</td><td class="right " data-stat="orb_pct" >6.6</td><td class="right " data-stat="drb_pct" >7.4</td><td class="right " data-stat="trb_pct" >7.0</td><td class="right " data-stat="ast_pct" >7.7</td><td class="right " data-stat="stl_pct" >3.2</td><td class="right " data-stat="blk_pct" >5.2</td><td class="right " data-stat="tov_pct" >0.0</td><td class="right " data-stat="usg_pct" >13.5</td><td class="right " data-stat="off_rtg" >95</td><td class="right " data-stat="def_rtg" >106</td></tr>
 
@@ -972,12 +2521,25 @@ sr_menus_setupMainNav_button_inline();
       </div>
    </div>
 </div>
+
+
+    </div>
+
+</div>
 <div>
-<strong>Inactive:</strong>&nbsp;
-<span><strong>SAS</strong>&nbsp;</span><a href="/players/f/forbebr01.html">Bryn Forbes</a>&nbsp;&nbsp;&nbsp;<span><strong>ATL</strong>&nbsp;</span><a href="/players/p/princta02.html">Taurean Waller-Prince</a>,&nbsp;<a href="/players/s/scottmi01.html">Mike Scott</a>,&nbsp;<a href="/players/s/splitti01.html">Tiago Splitter</a>&nbsp;&nbsp;&nbsp;<br>
-<strong>Officials:</strong>&nbsp;<a href="/referees/brownto99r.html">Tony Brown</a>, <a href="/referees/frahepa99r.html">Pat Fraher</a>, <a href="/referees/workmha01r.html">Haywoode Workman</a><br>
-<strong>Attendance:</strong>&nbsp;18,088<br>
-<strong>Time of Game:</strong>&nbsp;2:44<br>
+
+  <div><strong>Inactive:&nbsp;</strong><span><strong>SAS</strong>&nbsp;</span><a href="/players/f/forbebr01.html">Bryn Forbes</a>&nbsp;&nbsp;&nbsp;<span><strong>ATL</strong>&nbsp;</span><a href="/players/p/princta02.html">Taurean Waller-Prince</a>,&nbsp;<a href="/players/s/scottmi01.html">Mike Scott</a>,&nbsp;<a href="/players/s/splitti01.html">Tiago Splitter</a>&nbsp;&nbsp;&nbsp;</div>
+
+
+  <div><strong>Officials:&nbsp;</strong><a href='/referees/brownto99r.html'>Tony Brown</a>, <a href='/referees/frahepa99r.html'>Pat Fraher</a>, <a href='/referees/workmha01r.html'>Haywoode Workman</a></div>
+
+
+  <div><strong>Attendance:&nbsp;</strong>18,088</div>
+
+
+  <div><strong>Time of Game:&nbsp;</strong>2:44</div>
+
+
 </div>
 
 
@@ -985,19 +2547,19 @@ sr_menus_setupMainNav_button_inline();
 
 
 
-<!-- global.nonempty_tables_num: 1, table_count: 1 -->
+<!-- global.nonempty_tables_num: 3, table_count: 3 -->
    <!-- no Local/Partials/NoteBottom.tt2 -->
-<div id="bottom_nav" class="section_wrapper commented">
+<div id="bottom_nav" class="section_wrapper">
 <div class="section_heading"><span data-no-inpage="1" class="section_anchor" id="inner_nav_bottom_link" data-label="Team and League Schedules"></span><h2>Team and League Schedules</h2></div>
-<button id="bottom_nav_button" class="comment_control opener" data-type="hide_after" data-class="commented" data-id="bottom_nav">Team and League Schedules</button>
 <div class="section_content" id="bottom_nav_container">
+
+  <p><a href="/boxscores/"><u>Jan 1, 2017 NBA Scores & Boxes</u></a></p>
+
         <ul class="">
           <li><a href="/teams/SAS/2017_games.html"><u>San Antonio Spurs Schedule</u></a></li>
           <li><a href="/teams/ATL/2017_games.html"><u>Atlanta Hawks Schedule</u></a></li>
-          <li><a href="/leagues/NBA_2017_games.html"><u>2016-17 NBA Scores & Schedule</u></a></li>
-        </ul>
-</div>
-</div>
+          <li><a href="/leagues/NBA_2017_games.html"><u>2016-17 NBA Schedule & Results</u></a></li>
+        </ul></div></div>
 
 
 
@@ -1025,57 +2587,60 @@ sr_menus_setupMainNav_button_inline();
 
 <div id="footer" role="contentinfo">
 	<div id="footer_header">
-		 <ul class="bullets-inline"><li class="user logged_in">Welcome<span class="username"></span>&nbsp;&#183;&nbsp;<a href="/my/">Your Account</a></li>
+		 <ul class="bullets-inline"><li class="user logged_in">Welcome <span class="username"></span>&nbsp;&#183;&nbsp;<a href="/my/">Your Account</a></li>
 <li class="user logged_in"><a class="logout" href="/my/?do=logout">Logout</a></li>
 <li class="user not_logged_in"><a class="login" href="/my/">Login</a></li>
 <li class="user not_logged_in"><a href="/my/">Create Account</a></li>
 <li><a href="/my/?do=ad_free_browsing">Surf AD-FREE</a></li>
 </ul>
-		 <div class="breadcrumbs" itemscope itemtype="https://schema.org/Other">You are here: <span><a href="/">BBR Home</a></span> &gt; <span itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><a itemprop="item" href="/boxscores/index.cgi?month=1&amp;day=1&amp;year=2017"><span itemprop="name">Box Scores</span></a> <meta itemprop="position" content="1" /></span> &gt; <span itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><strong><span itemprop="name">San Antonio Spurs at Atlanta Hawks Box Score, January 1, 2017</span></strong> <meta itemprop="position" content="2" /></span></div>
+		 <div class="breadcrumbs" itemscope itemtype="https://schema.org/Other">You are here: <span><a href="/">BBR Home Page</a></span> &gt; <span itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><a itemprop="item" href="/boxscores/index.cgi?month=1&amp;day=1&amp;year=2017"><span itemprop="name">Box Scores</span></a> <meta itemprop="position" content="1" /></span> &gt; <strong>San Antonio Spurs at Atlanta Hawks Box Score, January 1, 2017</strong></div>
 	</div><!-- div#footer_header -->
 	<div id="site_menu" role="navigation" aria-label="complete site index">
+
 
 <div class="section_heading">
   <span class="section_anchor" id="site_menu_link" data-label="Full Site Menu" data-no-inpage="1"></span><h2>Full Site Menu</h2>    <div class="section_heading_text">
       <ul> <li><a data-scroll href="#header">Return to Top</a></li>
       </ul>
     </div>
+
 </div>
-		<ul>
+
+			<ul>
   <li>
     <a href="/players/">Players</a>
     <div><strong>In the News</strong>:
       <!-- Begin:In the News -->
-<a title="LeBron James" href="/players/j/jamesle01.html">L. James</a>,
-<a title="Anthony Davis" href="/players/d/davisan02.html">A. Davis</a>,
 <a title="Kevin Durant" href="/players/d/duranke01.html">K. Durant</a>,
-<a title="James Harden" href="/players/h/hardeja01.html">J. Harden</a>,
-<a title="Trevor Ariza" href="/players/a/arizatr01.html">T. Ariza</a>,
-<a title="Kawhi Leonard" href="/players/l/leonaka01.html">K. Leonard</a>
+<a title="LeBron James" href="/players/j/jamesle01.html">L. James</a>,
+<a title="Kawhi Leonard" href="/players/l/leonaka01.html">K. Leonard</a>,
+<a title="Anthony Davis" href="/players/d/davisan02.html">A. Davis</a>,
+<a title="Russell Westbrook" href="/players/w/westbru01.html">R. Westbrook</a>,
+<a title="Paul George" href="/players/g/georgpa01.html">P. George</a>
 <!-- End:In the News -->
       <a href="/players/">...</a>
     </div>
 
 	<div><strong>All-Time Greats</strong>:
       <!-- Begin:All-Time Greats -->
-<a title="John Stockton" href="/players/s/stockjo01.html">J. Stockton</a>,
-<a title="Jason Kidd" href="/players/k/kiddja01.html">J. Kidd</a>,
-<a title="Kevin Garnett" href="/players/g/garneke01.html">K. Garnett</a>,
-<a title="Kobe Bryant" href="/players/b/bryanko01.html">K. Bryant</a>,
-<a title="Wilt Chamberlain" href="/players/c/chambwi01.html">W. Chamberlain</a>,
-<a title="Bill Russell" href="/players/r/russebi01.html">B. Russell</a>
+<a title="Elgin Baylor" href="/players/b/bayloel01.html">E. Baylor</a>,
+<a title="Bob Cousy" href="/players/c/cousybo01.html">B. Cousy</a>,
+<a title="Elvin Hayes" href="/players/h/hayesel01.html">E. Hayes</a>,
+<a title="Karl Malone" href="/players/m/malonka01.html">K. Malone</a>,
+<a title="Jerry West" href="/players/w/westje01.html">J. West</a>,
+<a title="Wilt Chamberlain" href="/players/c/chambwi01.html">W. Chamberlain</a>
 <!-- End:All-Time Greats -->
       <a href="/players/">...</a>
     </div>
 
     <div><strong>Active Greats</strong>:
       <!-- Begin:Active Greats -->
-<a title="LeBron James" href="/players/j/jamesle01.html">L. James</a>,
 <a title="Chris Paul" href="/players/p/paulch01.html">C. Paul</a>,
-<a title="Kevin Durant" href="/players/d/duranke01.html">K. Durant</a>,
-<a title="Dirk Nowitzki" href="/players/n/nowitdi01.html">D. Nowitzki</a>,
 <a title="Dwyane Wade" href="/players/w/wadedw01.html">D. Wade</a>,
-<a title="Stephen Curry" href="/players/c/curryst01.html">S. Curry</a>
+<a title="Stephen Curry" href="/players/c/curryst01.html">S. Curry</a>,
+<a title="Kevin Durant" href="/players/d/duranke01.html">K. Durant</a>,
+<a title="LeBron James" href="/players/j/jamesle01.html">L. James</a>,
+<a title="Dirk Nowitzki" href="/players/n/nowitdi01.html">D. Nowitzki</a>
 <!-- End:Active Greats -->
       <a href="/players/">...</a>
     </div>
@@ -1254,10 +2819,10 @@ sr_menus_setupMainNav_button_inline();
   <li>
     <a href="/playoffs/">Playoffs</a>
     <div>
+      <a href="/playoffs/NBA_2019.html">2019 NBA Playoffs</a>,
       <a href="/playoffs/NBA_2018.html">2018 NBA Playoffs</a>,
       <a href="/playoffs/NBA_2017.html">2017 NBA Playoffs</a>,
       <a href="/playoffs/NBA_2016.html">2016 NBA Playoffs</a>,
-      <a href="/playoffs/NBA_2015.html">2015 NBA Playoffs</a>,
       <a href="/playoffs/">Playoffs Series History</a>
       ...
     </div>
@@ -1266,10 +2831,10 @@ sr_menus_setupMainNav_button_inline();
   <li>
     <a href="/allstar/">All-Star Games</a>
     <div>
+      <a href="/allstar/NBA_2019.html">2019 All-Star Game</a>,
       <a href="/allstar/NBA_2018.html">2018 All-Star Game</a>,
       <a href="/allstar/NBA_2017.html">2017 All-Star Game</a>,
       <a href="/allstar/NBA_2016.html">2016 All-Star Game</a>,
-      <a href="/allstar/NBA_2015.html">2015 All-Star Game</a>,
       ...
     </div>
   </li>
@@ -1277,11 +2842,11 @@ sr_menus_setupMainNav_button_inline();
   <li>
     <a href="/draft/">NBA Draft</a>
     <div>
+      <a href="/draft/NBA_2019.html">2019 Draft</a>,
       <a href="/draft/NBA_2018.html">2018 Draft</a>,
       <a href="/draft/NBA_2017.html">2017 Draft</a>,
       <a href="/draft/NBA_2016.html">2016 Draft</a>,
       <a href="/draft/NBA_2015.html">2015 Draft</a>,
-      <a href="/draft/NBA_2014.html">2014 Draft</a>,
       ...
     </div>
   </li>
@@ -1335,13 +2900,13 @@ sr_menus_setupMainNav_button_inline();
   </li>
 
   <li>
-    <a href="/euro/">Euro Basketball Stats</a>
+    <a href="/international/">International Basketball Stats</a>
     <div>
-      <a href="/euro/players/">Players</a>,
-      <a href="/euro/teams/">Teams</a>,
-      <a href="/euro/years/">Seasons</a>,
-      <a href="/euro/leaders/">Leaders</a>,
-      <a href="/euro/awards/">Awards</a>
+      <a href="/international/players/">Players</a>,
+      <a href="/international/teams/">Teams</a>,
+      <a href="/international/years/">Seasons</a>,
+      <a href="/international/leaders/">Leaders</a>,
+      <a href="/international/awards/">Awards</a>
       ...
     </div>
   </li>
@@ -1393,6 +2958,7 @@ sr_menus_setupMainNav_button_inline();
 
 
 
+
 	</div><!-- div#site_menu -->
 	<div id="social" class="icon_group noload">
 
@@ -1411,11 +2977,17 @@ sr_menus_setupMainNav_button_inline();
 	<a href="https://www.paypal.me/sportsref" data-tip="Send us money via PayPal" data-label="PayPal" class="poptip"><svg class="icon paypal"><use xlink:href="#ic-paypal"></use></svg></a>
 
 <p>Every <a href="https://www.sports-reference.com/blog/sports-reference-social-media/">Sports Reference Social Media Account</a></p>
-<p><strong>Site Last Updated:</strong> Friday, December 28, 11:35PM
+<p><strong>Site Last Updated:</strong> Saturday, September 28, 12:36PM
 </p>
 <p><a href="https://www.sports-reference.com/feedback/" class="button alt">Question, Comment, Feedback, or Correction?</a></p>
 
-<p><a style="background-color:#8e4496; color: #fff;" href="https://stathead.com/" class="button alt">Are you a Stathead, too? Subscribe to our Newsletter</a></p>
+<p><a style="background-color:#8e4496; color: #fff;" href="https://stathead.com/?&utm_medium=sr&utm_source=bbr&utm_campaign=site-footer" class="button alt">Are you a Stathead, too? Subscribe to our Newsletter</a></p>
+
+<p><a style="background-color:#155ca9; color: #fff;" href="https://www.sports-reference.com/this-week.html?&utm_medium=sr&utm_source=bbr&utm_campaign=site-footer-twisr" class="button alt">This Week in Sports Reference<br><em>Find out when we add a feature or make a change</em></a></p>
+
+<p><a href="https://www.sports-reference.com/blog/ways-sports-reference-can-help-your-website/?utm_medium=sr&utm_source=bbr&utm_campaign=site-footer-ways-help">Do you have a sports website? Or write about sports? We have tools and resources that can help you use sports data.  Find out more.</a></p>
+
+
 </div><!-- div#social -->
 
 	<div id="tips_tricks">
@@ -1436,20 +3008,22 @@ sr_menus_setupMainNav_button_inline();
 	<div id="credits">
         <p>All logos are the trademark &amp; property of their owners and not Sports Reference LLC.  We present them here for purely educational purposes.
         <a href="https://www.sports-reference.com/blog/2016/06/redesign-team-and-league-logos-courtesy-sportslogos-net/">Our reasoning for presenting offensive logos.</a></p>
-        <p>Logos were compiled by the amazing <a href="http://sportslogos.net/">SportsLogos.net.</a></p>
+        <p>
+
+				Logos were compiled by the amazing <a href="http://sportslogos.net/">SportsLogos.net.</a></p>
 
 
 <div class="notice">
 <p>Primary Data Provided By
-	<a href="https://www.sportradar.com/" rel="nofollow"><img alt="SportRadar" border=0 width=275 src="https://d2p3bygnnzw9w3.cloudfront.net/req/201811271/images/klecko/sportradar.png"  style="background-color:#666; padding:.5em; border-radius:.25em"></a>
+	<a href="https://www.sportradar.com/" rel="nofollow"><img alt="SportRadar" border=0 width=275 src="https://d2p3bygnnzw9w3.cloudfront.net/req/201909231/images/klecko/sportradar.png"  style="background-color:#666; padding:.5em; border-radius:.25em"></a>
 	the official stats partner of the NBA.</p>
 	<p>Basketball-Reference utilizes <strong>Official NBA data</strong> for current NBA, WNBA, and G-League seasons.</p>
-</div>
+	</div>
 
-     <p>Copyright &copy; 2000-2018 <a href="//www.sports-reference.com/">Sports Reference LLC</a>. All rights reserved.</p>
+     <p>Copyright &copy; 2000-2019 <a href="//www.sports-reference.com/">Sports Reference LLC</a>. All rights reserved.</p>
 
 </div><!-- div#credits -->
-	<ul id="site_dirs" class="bullets-inline">
+	<ul id="site_dirs" class="notranslate bullets-inline">
 	<li><a href="https://www.sports-reference.com/"><svg height="15px" width="20px"><use xlink:href="#ic-sr-pennant"></use></svg> Sports Reference</a></li>
 	<li><a href="https://www.baseball-reference.com/">Baseball</a></li>
 	<li><a href="https://www.pro-football-reference.com/">Football</a> <a href="https://www.sports-reference.com/cfb/">(college)</a></li>
@@ -1468,6 +3042,11 @@ sr_menus_setupMainNav_button_inline();
 
 </div><!-- div#footer -->
 </div><!-- div#wrap -->
+<!-- yes sticky url:  https://www.basketball-reference.com/boxscores/201701010ATL.html -->
+<div id="fs-select-footer"></div>
+
+
+
 
 <!-- rails -->
 
@@ -1499,7 +3078,7 @@ sr_menus_setupMainNav_button_inline();
 </div>
 
 
-<!-- Google Analytics --><script> String.prototype.sr_isMatch = function(s){ return this.match(s)!==null}; function getCookie(name) { var prefix = name + "="; var begin = document.cookie.indexOf("; " + prefix); if (begin == -1) { begin = document.cookie.indexOf(prefix); if (begin != 0) return null; } else { begin += 2; var end = document.cookie.indexOf(";", begin); if (end == -1) { end = document.cookie.length; } } return unescape(document.cookie.substring(begin + prefix.length, end));} var sr_cookie = getCookie('SR_user') || ''; var sr_is_ad_free = sr_cookie.sr_isMatch('Z6SON8tTdJid'); var sr_is_user = sr_cookie !== null && sr_cookie !== ''; var sr_seen_modal = getCookie('modal_ad') !== null; (function(i,s,o,g,r,a,m){ i['GoogleAnalyticsObject']=r; i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date(); a=s.createElement(o),m=s.getElementsByTagName(o)[0]; a.async=1; a.src=g; m.parentNode.insertBefore(a,m) })(window,document,'script','https://www.google-analytics.com/analytics.js','ga'); ga('create', 'UA-1890630-2', 'auto'); ga('require', 'linkid', 'linkid.js'); ga('require', 'ecommerce', 'ecommerce.js'); ga('send', 'pageview'); ga('create', 'UA-1890630-20', 'auto', {'name': 'combined_tracker', 'allowLinker': true }); ga('combined_tracker.send', 'pageview'); var sr_device = 'unk'; if (Modernizr.phone) { sr_device = 'phone'; } else if (Modernizr.tablet) { sr_device = 'tablet'; } else if (Modernizr.laptop) { sr_device = 'laptop'; } else if (Modernizr.desktop) { sr_device = 'desktop'; } ga('create', 'UA-1890630-9', 'auto', {'name': 'sr_tracker', 'allowLinker': true }); ga('sr_tracker.require', 'displayfeatures'); ga('sr_tracker.set', 'dimension1','bbr'); ga('sr_tracker.set', 'dimension2',sr_is_ad_free); ga('sr_tracker.set', 'dimension3',sr_is_user); ga('sr_tracker.set', 'dimension4',sr_seen_modal); ga('sr_tracker.set', 'dimension5',sr_device); ga('sr_tracker.set', 'dimension6',Modernizr.is_modern?'yes':'no'); ga('sr_tracker.set', 'dimension7',Modernizr.viewport_width); /* note that this requires the Assets/AdBlockTest.tt2 to be included above. */ ga('sr_tracker.set', 'dimension8',(typeof sr_test == 'undefined')?'no-test':( sr_test ? 'non-blocking':'blocking')); ga('sr_tracker.send', 'pageview'); /* cribbed from: http://www.axllent.org/docs/view/track-outbound-links-with-analytics-js/ */ function _gaLt(event) { if (!ga.hasOwnProperty("loaded") || ga.loaded != true) { return; } var el = event.srcElement || event.target; /* if a link has been clicked */ if (el && el.href) { var link = el.href; /* Only if it is an external link */ if (link.indexOf(location.host) == -1 && !link.match(/^javascript\:/i)) { /* Is target set and not _(self|parent|top)? */ var target = (el.target && !el.target.match(/^_(self|parent|top)/i)) ? el.target : false; /* If target opens a new window then just track */ if (el.target && !el.target.match(/^_(self|parent|top)/i)) { ga("send", "event", "Outgoing Links", link, document.location.pathname + document.location.search); } }; } } window.addEventListener ? window.addEventListener("load", function() { document.body.addEventListener("click", _gaLt, !1)}, !1) : window.attachEvent && window.attachEvent("onload", function() { document.body.attachEvent("onclick", _gaLt) }); </script><!-- End Google Analytics -->
+<!-- Google Analytics --><script> var sr_cookie = vjs_readCookie('SR_user') || ''; var sr_is_ad_free = sr_cookie.vjs_isMatch('Z6SON8tTdJid'); var sr_is_user = sr_cookie !== null && sr_cookie !== ''; var sr_seen_modal = vjs_readCookie('modal_ad') !== null; (function(i,s,o,g,r,a,m){ i['GoogleAnalyticsObject']=r; i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date(); a=s.createElement(o),m=s.getElementsByTagName(o)[0]; a.async=1; a.src=g; m.parentNode.insertBefore(a,m) })(window,document,'script','https://www.google-analytics.com/analytics.js','ga'); ga('create', 'UA-1890630-2', 'auto'); ga('require', 'linkid', 'linkid.js'); ga('require', 'ecommerce', 'ecommerce.js'); ga('send', 'pageview'); ga('create', 'UA-1890630-20', 'auto', {'name': 'combined_tracker', 'allowLinker': true }); ga('combined_tracker.send', 'pageview'); var sr_device = 'unk'; if (Modernizr.phone) { sr_device = 'phone'; } else if (Modernizr.tablet) { sr_device = 'tablet'; } else if (Modernizr.laptop) { sr_device = 'laptop'; } else if (Modernizr.desktop) { sr_device = 'desktop'; } ga('create', 'UA-1890630-9', 'auto', {'name': 'sr_tracker', 'allowLinker': true }); ga('sr_tracker.require', 'displayfeatures'); ga('sr_tracker.set', 'dimension1','bbr'); ga('sr_tracker.set', 'dimension2',sr_is_ad_free); ga('sr_tracker.set', 'dimension3',sr_is_user); ga('sr_tracker.set', 'dimension4',sr_seen_modal); ga('sr_tracker.set', 'dimension5',sr_device); ga('sr_tracker.set', 'dimension6',Modernizr.is_modern?'yes':'no'); ga('sr_tracker.set', 'dimension7',Modernizr.viewport_width); /* note that this requires the Assets/AdBlockTest.tt2 to be included above. */ ga('sr_tracker.set', 'dimension8',(typeof sr_test == 'undefined')?'no-test':( sr_test ? 'non-blocking':'blocking')); ga('sr_tracker.send', 'pageview'); /* cribbed from: http://www.axllent.org/docs/view/track-outbound-links-with-analytics-js/ */ function _gaLt(event) { if (!ga.hasOwnProperty("loaded") || ga.loaded != true) { return; } var el = event.srcElement || event.target; /* if a link has been clicked */ if (el && el.href) { var link = el.href; /* Only if it is an external link */ if (link.indexOf(location.host) == -1 && !link.match(/^javascript\:/i)) { /* Is target set and not _(self|parent|top)? */ var target = (el.target && !el.target.match(/^_(self|parent|top)/i)) ? el.target : false; /* If target opens a new window then just track */ if (el.target && !el.target.match(/^_(self|parent|top)/i)) { ga("send", "event", "Outgoing Links", link, document.location.pathname + document.location.search); } }; } } window.addEventListener ? window.addEventListener("load", function() { document.body.addEventListener("click", _gaLt, !1)}, !1) : window.attachEvent && window.attachEvent("onload", function() { document.body.attachEvent("onclick", _gaLt) }); </script><!-- End Google Analytics -->
 </body><!-- SR -->
 </html>
 


### PR DESCRIPTION
Resolves #99.

BBref added stats tables for quarters, which also had `basic` in the `id` value.

![image](https://user-images.githubusercontent.com/8136030/65930744-abaad580-e3bb-11e9-9484-85a3fbcfb7cc.png)

This meant that the number of matching footers was much higher.

Instead, I check for `game-basic` `id` values.

This probably requires a more robust solution in the future, but this is my strategy for now.
