### PR TITLE
Add unit tests for SchedulePage and ScheduleRow

### DIFF
--- a/basketball_reference_web_scraper/html.py
+++ b/basketball_reference_web_scraper/html.py
@@ -634,6 +634,11 @@ class ScheduleRow:
     def __init__(self, html):
         self.html = html
 
+    def __eq__(self, other):
+        if isinstance(other, ScheduleRow):
+            return self.html == other.html
+        return False
+
     @property
     def start_date(self):
         return self.html[0].text_content()

--- a/tests/test_schedule_page.py
+++ b/tests/test_schedule_page.py
@@ -1,0 +1,71 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch, PropertyMock
+
+from basketball_reference_web_scraper.html import SchedulePage, ScheduleRow
+
+
+class TestSchedulePage(TestCase):
+    def setUp(self):
+        self.html = MagicMock()
+
+    def test_other_months_schedule_links_query(self):
+        self.assertEqual(
+            SchedulePage(html=self.html).other_months_schedule_links_query,
+            '//div[@id="content"]/div[@class="filter"]/div[not(contains(@class, "current"))]/a'
+        )
+
+    def test_rows_query(self):
+        self.assertEqual(
+            SchedulePage(html=self.html).rows_query,
+            '//table[@id="schedule"]//tbody/tr'
+        )
+
+    @patch.object(SchedulePage, 'other_months_schedule_links_query', new_callable=PropertyMock)
+    def test_other_months_schedule_urls(self, mocked_other_months_schedule_links_query):
+        query = "some query"
+        mocked_other_months_schedule_links_query.return_value = query
+        link_href = "some link href"
+        link = MagicMock()
+        link.attrib = MagicMock()
+        link.attrib.__getitem__ = MagicMock(return_value=link_href)
+        links = [link]
+        self.html.xpath = MagicMock(return_value=links)
+
+        self.assertEqual(
+            SchedulePage(html=self.html).other_months_schedule_urls,
+            [link_href]
+        )
+        self.html.xpath.assert_called_once_with(query)
+        link.attrib.__getitem__.assert_called_once_with('href')
+
+    @patch.object(SchedulePage, 'rows_query', new_callable=PropertyMock)
+    def test_no_rows_are_returned_when_all_rows_have_playoffs_content(self, mocked_rows_query):
+        query = "some query"
+        mocked_rows_query.return_value = query
+        playoff_row = MagicMock()
+        playoff_row.text_content = MagicMock(return_value="Playoffs")
+        rows = [playoff_row]
+        self.html.xpath = MagicMock(return_value=rows)
+
+        self.assertEqual(
+            SchedulePage(html=self.html).rows,
+            []
+        )
+        self.html.xpath.assert_called_once_with(query)
+        playoff_row.text_content.assert_called_once_with()
+
+    @patch.object(SchedulePage, 'rows_query', new_callable=PropertyMock)
+    def test_all_rows_are_returned_when_all_rows_have_playoffs_content(self, mocked_rows_query):
+        query = "some query"
+        mocked_rows_query.return_value = query
+        non_playoff_row = MagicMock()
+        non_playoff_row.text_content = MagicMock(return_value="jaebaebae")
+        rows = [non_playoff_row]
+        self.html.xpath = MagicMock(return_value=rows)
+
+        self.assertEqual(
+            SchedulePage(html=self.html).rows,
+            [
+                ScheduleRow(html=non_playoff_row)
+            ]
+        )

--- a/tests/test_schedule_row.py
+++ b/tests/test_schedule_row.py
@@ -1,0 +1,75 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from basketball_reference_web_scraper.html import ScheduleRow
+
+
+class TestScheduleRow(TestCase):
+    def setUp(self):
+        self.html = MagicMock()
+
+    def test_instance_is_not_equal_to_different_class_instance(self):
+        self.assertNotEqual(ScheduleRow(html=MagicMock()), 1)
+
+    def test_instance_is_not_equal_to_same_class_instance_if_html_is_different(self):
+        self.assertNotEqual(ScheduleRow(html=MagicMock()), ScheduleRow(html=MagicMock()))
+
+    def test_start_date(self):
+        start_date = "some start date"
+        start_date_cell = MagicMock()
+        start_date_cell.text_content = MagicMock(return_value=start_date)
+        self.html.__getitem__ = MagicMock(return_value=start_date_cell)
+
+        self.assertEqual(ScheduleRow(html=self.html).start_date, start_date)
+        self.html.__getitem__.assert_called_once_with(0)
+        start_date_cell.text_content.assert_called_once_with()
+
+    def test_start_time_of_day(self):
+        start_time_of_day = "some start time of day"
+        start_time_of_day_cell = MagicMock()
+        start_time_of_day_cell.text_content = MagicMock(return_value=start_time_of_day)
+        self.html.__getitem__ = MagicMock(return_value=start_time_of_day_cell)
+
+        self.assertEqual(ScheduleRow(html=self.html).start_time_of_day, start_time_of_day)
+        self.html.__getitem__.assert_called_once_with(1)
+        start_time_of_day_cell.text_content.assert_called_once_with()
+
+    def test_away_team_name(self):
+        away_team_name = "some away team name"
+        away_team_name_cell = MagicMock()
+        away_team_name_cell.text_content = MagicMock(return_value=away_team_name)
+        self.html.__getitem__ = MagicMock(return_value=away_team_name_cell)
+
+        self.assertEqual(ScheduleRow(html=self.html).away_team_name, away_team_name)
+        self.html.__getitem__.assert_called_once_with(2)
+        away_team_name_cell.text_content.assert_called_once_with()
+
+    def test_home_team_name(self):
+        home_team_name = "some home team name"
+        home_team_name_cell = MagicMock()
+        home_team_name_cell.text_content = MagicMock(return_value=home_team_name)
+        self.html.__getitem__ = MagicMock(return_value=home_team_name_cell)
+
+        self.assertEqual(ScheduleRow(html=self.html).home_team_name, home_team_name)
+        self.html.__getitem__.assert_called_once_with(4)
+        home_team_name_cell.text_content.assert_called_once_with()
+
+    def test_away_team_score(self):
+        away_team_score = "some away team score"
+        away_team_score_cell = MagicMock()
+        away_team_score_cell.text_content = MagicMock(return_value=away_team_score)
+        self.html.__getitem__ = MagicMock(return_value=away_team_score_cell)
+
+        self.assertEqual(ScheduleRow(html=self.html).away_team_score, away_team_score)
+        self.html.__getitem__.assert_called_once_with(3)
+        away_team_score_cell.text_content.assert_called_once_with()
+
+    def test_home_team_score(self):
+        home_team_score = "some home team score"
+        home_team_score_cell = MagicMock()
+        home_team_score_cell.text_content = MagicMock(return_value=home_team_score)
+        self.html.__getitem__ = MagicMock(return_value=home_team_score_cell)
+
+        self.assertEqual(ScheduleRow(html=self.html).home_team_score, home_team_score)
+        self.html.__getitem__.assert_called_once_with(5)
+        home_team_score_cell.text_content.assert_called_once_with()


### PR DESCRIPTION
* Adds unit tests for `SchedulePage` and `ScheduleRow` classes.
* Overrides the `__eq__` method on `ScheduleRow` that compares the reference of `self.html` to determine equality