### PR TITLE
Update test execution in Travis build

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,5 @@ exclude_lines =
     pragma: no cover
     raise NotImplementedError
     if __name__ == .__main__.:
-ignore_errors = True
 omit =
     tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,13 @@ python:
   - "3.6"
   - "3.6-dev"
   - "3.7-dev"
+before_install:
+  # Update pip to latest version as some builds will fail without this
+  - pip install -U pip
+  - pip install codecov
 install:
   - pip install -r requirements.txt
 script:
-  - pip install -e .
-  - pytest --cov=./
+  - coverage run -m unittest tests
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,10 @@ python:
   - "3.6-dev"
   - "3.7-dev"
 before_install:
-  # Update pip to latest version as some builds will fail without this
-  - pip install -U pip
   - pip install codecov
 install:
   - pip install -r requirements.txt
 script:
-  - coverage run -m unittest tests
+  - coverage run -m unittest discover
 after_success:
   - codecov

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,15 +2,12 @@ atomicwrites==1.2.1
 attrs==18.2.0
 certifi==2018.10.15
 chardet==3.0.4
-codecov==2.0.15
 coverage==4.5.1
 idna==2.7
 lxml==4.2.5
 more-itertools==4.3.0
 pluggy==0.8.0
 py==1.7.0
-pytest==3.9.3
-pytest-cov==2.6.0
 pytz==2018.6
 requests==2.20.0
 six==1.11.0


### PR DESCRIPTION
Was having trouble getting `pytest` to run correctly locally so decided to switch to using builtin `unittest` for local test execution as well as for test execution in Travis build.

This also meant removing `pytest` and `pytest-cov` from `requirements.txt`.

I removed `codecov` from `requirements.txt` as well as since it's only necessary during Travis build execution and instead install the dependency as part of the `before_install` stage.