### PR TITLE
Add Outcomes and Points to Team Box Scores

### DIFF
--- a/basketball_reference_web_scraper/data.py
+++ b/basketball_reference_web_scraper/data.py
@@ -248,3 +248,7 @@ class TeamTotal:
     @property
     def personal_fouls(self):
         return self.totals.personal_fouls
+
+    @property
+    def points(self):
+        return self.totals.points

--- a/basketball_reference_web_scraper/html.py
+++ b/basketball_reference_web_scraper/html.py
@@ -382,6 +382,10 @@ class TeamTotalRow:
     def personal_fouls(self):
         return self.html[17].text_content()
 
+    @property
+    def points(self):
+        return self.html[18].text_content()
+
 
 class DailyLeadersPage:
     def __init__(self, html):

--- a/basketball_reference_web_scraper/http_client.py
+++ b/basketball_reference_web_scraper/http_client.py
@@ -183,7 +183,10 @@ def team_box_score(game_url_path):
         abbreviations_to_teams=TEAM_ABBREVIATIONS_TO_TEAM,
     ))
 
-    return parser.parse(combined_team_totals)
+    return parser.parse(
+        first_team_totals=combined_team_totals[0],
+        second_team_totals=combined_team_totals[1],
+    )
 
 
 def team_box_scores(day, month, year):

--- a/basketball_reference_web_scraper/parsers.py
+++ b/basketball_reference_web_scraper/parsers.py
@@ -1,9 +1,9 @@
 import re
-from datetime import datetime, date
+from datetime import datetime
 
 import pytz
 
-from basketball_reference_web_scraper.data import PeriodType
+from basketball_reference_web_scraper.data import PeriodType, Outcome
 from basketball_reference_web_scraper.utilities import str_to_int, str_to_float
 
 PLAYER_SEASON_BOX_SCORES_GAME_DATE_FORMAT = '%Y-%m-%d'
@@ -303,26 +303,47 @@ class TeamTotalsParser:
     def __init__(self, team_abbreviation_parser):
         self.team_abbreviation_parser = team_abbreviation_parser
 
-    def parse(self, totals):
+    def parse(self, first_team_totals, second_team_totals):
         return [
-            {
-                "team": self.team_abbreviation_parser.from_abbreviation(total.team_abbreviation),
-                "minutes_played": str_to_int(total.minutes_played),
-                "made_field_goals": str_to_int(total.made_field_goals),
-                "attempted_field_goals": str_to_int(total.attempted_field_goals),
-                "made_three_point_field_goals": str_to_int(total.made_three_point_field_goals),
-                "attempted_three_point_field_goals": str_to_int(total.attempted_three_point_field_goals),
-                "made_free_throws": str_to_int(total.made_free_throws),
-                "attempted_free_throws": str_to_int(total.attempted_free_throws),
-                "offensive_rebounds": str_to_int(total.offensive_rebounds),
-                "defensive_rebounds": str_to_int(total.defensive_rebounds),
-                "assists": str_to_int(total.assists),
-                "steals": str_to_int(total.steals),
-                "blocks": str_to_int(total.blocks),
-                "turnovers": str_to_int(total.turnovers),
-                "personal_fouls": str_to_int(total.personal_fouls),
-            } for total in totals
+            self.parse_totals(
+                team_totals=first_team_totals,
+                opposing_team_totals=second_team_totals,
+            ),
+            self.parse_totals(
+                team_totals=second_team_totals,
+                opposing_team_totals=first_team_totals,
+            ),
         ]
+
+    def parse_totals(self, team_totals, opposing_team_totals):
+        current_team = self.team_abbreviation_parser.from_abbreviation(team_totals.team_abbreviation)
+
+        if str_to_int(team_totals.points) > str_to_int(opposing_team_totals.points):
+            outcome = Outcome.WIN
+        elif str_to_int(team_totals.points) < str_to_int(opposing_team_totals.points):
+            outcome = Outcome.LOSS
+        else:
+            outcome = None
+
+        return {
+            "team": current_team,
+            "outcome": outcome,
+            "minutes_played": str_to_int(team_totals.minutes_played),
+            "made_field_goals": str_to_int(team_totals.made_field_goals),
+            "attempted_field_goals": str_to_int(team_totals.attempted_field_goals),
+            "made_three_point_field_goals": str_to_int(team_totals.made_three_point_field_goals),
+            "attempted_three_point_field_goals": str_to_int(team_totals.attempted_three_point_field_goals),
+            "made_free_throws": str_to_int(team_totals.made_free_throws),
+            "attempted_free_throws": str_to_int(team_totals.attempted_free_throws),
+            "offensive_rebounds": str_to_int(team_totals.offensive_rebounds),
+            "defensive_rebounds": str_to_int(team_totals.defensive_rebounds),
+            "assists": str_to_int(team_totals.assists),
+            "steals": str_to_int(team_totals.steals),
+            "blocks": str_to_int(team_totals.blocks),
+            "turnovers": str_to_int(team_totals.turnovers),
+            "personal_fouls": str_to_int(team_totals.personal_fouls),
+            "points": str_to_int(team_totals.points),
+        }
 
 
 class PlayerBoxScoresParser:

--- a/tests/test_integration_client.py
+++ b/tests/test_integration_client.py
@@ -201,48 +201,6 @@ class TestClient(TestCase):
         self.assertIsNotNone(player_season_totals)
         self.assertTrue(len(player_season_totals) > 0)
 
-    def test_2018_01_01_team_box_scores(self):
-        team_box_scores = client.team_box_scores(day=1, month=1, year=2018)
-        self.assertIsNotNone(team_box_scores)
-
-    def test_2001_01_01_team_box_scores(self):
-        team_box_scores = client.team_box_scores(day=1, month=1, year=2001)
-        self.assertIsNotNone(team_box_scores)
-
-    def test_2004_01_02_team_box_scores(self):
-        team_box_scores = client.team_box_scores(day=2, month=1, year=2004)
-        self.assertIsNotNone(team_box_scores)
-
-    def test_2018_01_01_team_box_scores_json_box_scores_to_file(self):
-        client.team_box_scores(
-            day=1,
-            month=1,
-            year=2018,
-            output_type=OutputType.JSON,
-            output_file_path="./2018_01_01_team_box_scores.json",
-            output_write_option=OutputWriteOption.WRITE
-        )
-
-    def test_2018_01_01_team_box_scores_json_box_scores_to_memory(self):
-        january_first_box_scores = client.team_box_scores(
-            day=1,
-            month=1,
-            year=2018,
-            output_type=OutputType.JSON,
-        )
-
-        self.assertIsNotNone(january_first_box_scores)
-
-    def test_2018_01_01_team_box_scores_csv_box_scores_to_file(self):
-        client.team_box_scores(
-            day=1,
-            month=1,
-            year=2018,
-            output_type=OutputType.CSV,
-            output_file_path="./2018_01_01_team_box_scores.csv",
-            output_write_option=OutputWriteOption.WRITE
-        )
-
     def test_BOS_2018_10_16_play_by_play(self):
         play_by_play = client.play_by_play(
             home_team=Team.BOSTON_CELTICS,

--- a/tests/test_integration_parse_teams.py
+++ b/tests/test_integration_parse_teams.py
@@ -4,7 +4,7 @@ import requests
 from lxml import html
 
 from basketball_reference_web_scraper.data import TEAM_ABBREVIATIONS_TO_TEAM, TeamTotal
-from basketball_reference_web_scraper.data import Team
+from basketball_reference_web_scraper.data import Team, Outcome
 from basketball_reference_web_scraper.html import BoxScoresPage
 from basketball_reference_web_scraper.parsers import TeamAbbreviationParser, \
     TeamTotalsParser
@@ -24,7 +24,10 @@ class TestParseTeams(TestCase):
             for table in self.page.basic_statistics_tables
         ]
         self.parser = TeamTotalsParser(team_abbreviation_parser=self.team_abbreviation_parser)
-        self.team_totals = self.parser.parse(self.combined_team_totals)
+        self.team_totals = self.parser.parse(
+            first_team_totals=self.combined_team_totals[0],
+            second_team_totals=self.combined_team_totals[1],
+        )
 
     def test_parse_two_team_totals(self):
         self.assertEqual(len(self.team_totals), 2)
@@ -32,6 +35,7 @@ class TestParseTeams(TestCase):
     def test_parse_san_antonio_team_totals(self):
         sas_team_totals = self.team_totals[0]
         self.assertEqual(sas_team_totals["team"], Team.SAN_ANTONIO_SPURS)
+        self.assertEqual(sas_team_totals["outcome"], Outcome.WIN)
         self.assertEqual(sas_team_totals["minutes_played"], 265)
         self.assertEqual(sas_team_totals["made_field_goals"], 42)
         self.assertEqual(sas_team_totals["attempted_field_goals"], 90)
@@ -46,10 +50,12 @@ class TestParseTeams(TestCase):
         self.assertEqual(sas_team_totals["blocks"], 6)
         self.assertEqual(sas_team_totals["turnovers"], 12)
         self.assertEqual(sas_team_totals["personal_fouls"], 21)
+        self.assertEqual(sas_team_totals["points"], 112)
 
     def test_parse_atlanta_team_totals(self):
         atl_team_totals = self.team_totals[1]
         self.assertEqual(atl_team_totals["team"], Team.ATLANTA_HAWKS)
+        self.assertEqual(atl_team_totals["outcome"], Outcome.LOSS)
         self.assertEqual(atl_team_totals["minutes_played"], 265)
         self.assertEqual(atl_team_totals["made_field_goals"], 42)
         self.assertEqual(atl_team_totals["attempted_field_goals"], 92)
@@ -64,3 +70,4 @@ class TestParseTeams(TestCase):
         self.assertEqual(atl_team_totals["blocks"], 6)
         self.assertEqual(atl_team_totals["turnovers"], 11)
         self.assertEqual(atl_team_totals["personal_fouls"], 21)
+        self.assertEqual(atl_team_totals["points"], 114)

--- a/tests/test_integration_parse_teams.py
+++ b/tests/test_integration_parse_teams.py
@@ -35,7 +35,7 @@ class TestParseTeams(TestCase):
     def test_parse_san_antonio_team_totals(self):
         sas_team_totals = self.team_totals[0]
         self.assertEqual(sas_team_totals["team"], Team.SAN_ANTONIO_SPURS)
-        self.assertEqual(sas_team_totals["outcome"], Outcome.WIN)
+        self.assertEqual(sas_team_totals["outcome"], Outcome.LOSS)
         self.assertEqual(sas_team_totals["minutes_played"], 265)
         self.assertEqual(sas_team_totals["made_field_goals"], 42)
         self.assertEqual(sas_team_totals["attempted_field_goals"], 90)
@@ -55,7 +55,7 @@ class TestParseTeams(TestCase):
     def test_parse_atlanta_team_totals(self):
         atl_team_totals = self.team_totals[1]
         self.assertEqual(atl_team_totals["team"], Team.ATLANTA_HAWKS)
-        self.assertEqual(atl_team_totals["outcome"], Outcome.LOSS)
+        self.assertEqual(atl_team_totals["outcome"], Outcome.WIN)
         self.assertEqual(atl_team_totals["minutes_played"], 265)
         self.assertEqual(atl_team_totals["made_field_goals"], 42)
         self.assertEqual(atl_team_totals["attempted_field_goals"], 92)

--- a/tests/test_integration_player_regular_season_box_scores.py
+++ b/tests/test_integration_player_regular_season_box_scores.py
@@ -1,5 +1,5 @@
 import json
-from datetime import date, datetime
+from datetime import datetime
 from unittest import TestCase, mock
 
 from requests import HTTPError, codes

--- a/tests/test_integration_team_box_scores.py
+++ b/tests/test_integration_team_box_scores.py
@@ -1,0 +1,79 @@
+from unittest import TestCase
+
+import basketball_reference_web_scraper.client as client
+from basketball_reference_web_scraper.data import OutputWriteOption, OutputType, Team, Outcome
+
+
+class TestTeamBoxScores(TestCase):
+    def test_2018_01_01_team_box_scores(self):
+        team_box_scores = client.team_box_scores(day=1, month=1, year=2018)
+        self.assertIsNotNone(team_box_scores)
+
+    def test_2001_01_01_team_box_scores(self):
+        team_box_scores = client.team_box_scores(day=1, month=1, year=2001)
+        self.assertIsNotNone(team_box_scores)
+
+    def test_2004_01_02_team_box_scores(self):
+        team_box_scores = client.team_box_scores(day=2, month=1, year=2004)
+        self.assertIsNotNone(team_box_scores)
+
+    def test_2018_01_01_team_box_scores_json_box_scores_to_file(self):
+        client.team_box_scores(
+            day=1,
+            month=1,
+            year=2018,
+            output_type=OutputType.JSON,
+            output_file_path="./2018_01_01_team_box_scores.json",
+            output_write_option=OutputWriteOption.WRITE
+        )
+
+    def test_2018_01_01_team_box_scores_json_box_scores_to_memory(self):
+        january_first_box_scores = client.team_box_scores(
+            day=1,
+            month=1,
+            year=2018,
+            output_type=OutputType.JSON,
+        )
+
+        self.assertIsNotNone(january_first_box_scores)
+
+    def test_2018_01_01_team_box_scores_csv_box_scores_to_file(self):
+        client.team_box_scores(
+            day=1,
+            month=1,
+            year=2018,
+            output_type=OutputType.CSV,
+            output_file_path="./2018_01_01_team_box_scores.csv",
+            output_write_option=OutputWriteOption.WRITE
+        )
+
+    def test_2019_10_22_has_four_team_box_scores(self):
+        team_box_scores = client.team_box_scores(day=22, month=10, year=2019)
+        self.assertEqual(4, len(team_box_scores))
+
+    def test_2019_10_22_box_score_teams_and_outcomes(self):
+        team_box_scores = client.team_box_scores(day=22, month=10, year=2019)
+        lakers_box_score = team_box_scores[0]
+
+        self.assertEqual(Team.LOS_ANGELES_LAKERS, lakers_box_score["team"])
+        self.assertEqual(Outcome.LOSS, lakers_box_score["outcome"])
+        self.assertEqual(102, lakers_box_score["points"])
+
+        clippers_box_score = team_box_scores[1]
+
+        self.assertEqual(Team.LOS_ANGELES_CLIPPERS, clippers_box_score["team"])
+        self.assertEqual(Outcome.WIN, clippers_box_score["outcome"])
+        self.assertEqual(112, clippers_box_score["points"])
+
+        pelicans_box_score = team_box_scores[2]
+
+        self.assertEqual(Team.NEW_ORLEANS_PELICANS, pelicans_box_score["team"])
+        self.assertEqual(Outcome.LOSS, pelicans_box_score["outcome"])
+        self.assertEqual(122, pelicans_box_score["points"])
+
+        raptors_box_score = team_box_scores[3]
+
+        self.assertEqual(Team.TORONTO_RAPTORS, raptors_box_score["team"])
+        self.assertEqual(Outcome.WIN, raptors_box_score["outcome"])
+        self.assertEqual(130, raptors_box_score["points"])
+

--- a/tests/test_player_season_box_scores_page.py
+++ b/tests/test_player_season_box_scores_page.py
@@ -1,7 +1,6 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, PropertyMock, patch
 
-
 from basketball_reference_web_scraper.html import PlayerSeasonBoxScoresPage
 
 


### PR DESCRIPTION
### Summary

Adds `outcome` and `points` fields to the values returned by the `team_box_scores` method.

The `outcome` indicates whether the relevant team won or lost the game.

While #126 indicated that there might be a way to parse `div`s with the `game_summary current` class name, it looks like these `div`s are rendered by JavaScript post-page load.

Instead, I'm just doing a comparison of the two team box score totals, which meant slightly refactoring the `TeamTotalsParser` to take two explicit values instead of a list of values (which should always have been two).

Closes #126  