### PR TITLE
Use data-stat property for TeamTotalRow class when parsing box scores

### DIFF
--- a/basketball_reference_web_scraper/html.py
+++ b/basketball_reference_web_scraper/html.py
@@ -461,7 +461,11 @@ class StatisticsTable:
     @property
     def team_totals(self):
         # Team totals are stored as table footers
-        return TeamTotalRow(self.html.xpath('tfoot/tr/td'))
+        footers = self.html.xpath('tfoot/tr')
+        if len(footers) > 0:
+            return TeamTotalRow(html=footers[0])
+
+        return None
 
 
 class TeamTotalRow:

--- a/basketball_reference_web_scraper/html.py
+++ b/basketball_reference_web_scraper/html.py
@@ -470,63 +470,138 @@ class TeamTotalRow:
 
     @property
     def minutes_played(self):
-        return self.html[0].text_content()
+        cells = self.html.xpath('td[@data-stat="mp"]')
+
+        if len(cells) > 0:
+            return cells[0].text_content()
+
+        return ''
 
     @property
     def made_field_goals(self):
-        return self.html[1].text_content()
+        cells = self.html.xpath('td[@data-stat="fg"]')
+
+        if len(cells) > 0:
+            return cells[0].text_content()
+
+        return ''
 
     @property
     def attempted_field_goals(self):
-        return self.html[2].text_content()
+        cells = self.html.xpath('td[@data-stat="fga"]')
+
+        if len(cells) > 0:
+            return cells[0].text_content()
+
+        return ''
 
     @property
     def made_three_point_field_goals(self):
-        return self.html[4].text_content()
+        cells = self.html.xpath('td[@data-stat="fg3"]')
+
+        if len(cells) > 0:
+            return cells[0].text_content()
+
+        return ''
 
     @property
     def attempted_three_point_field_goals(self):
-        return self.html[5].text_content()
+        cells = self.html.xpath('td[@data-stat="fg3a"]')
+
+        if len(cells) > 0:
+            return cells[0].text_content()
+
+        return ''
 
     @property
     def made_free_throws(self):
-        return self.html[7].text_content()
+        cells = self.html.xpath('td[@data-stat="ft"]')
+
+        if len(cells) > 0:
+            return cells[0].text_content()
+
+        return ''
 
     @property
     def attempted_free_throws(self):
-        return self.html[8].text_content()
+        cells = self.html.xpath('td[@data-stat="fta"]')
+
+        if len(cells) > 0:
+            return cells[0].text_content()
+
+        return ''
 
     @property
     def offensive_rebounds(self):
-        return self.html[10].text_content()
+        cells = self.html.xpath('td[@data-stat="orb"]')
+
+        if len(cells) > 0:
+            return cells[0].text_content()
+
+        return ''
 
     @property
     def defensive_rebounds(self):
-        return self.html[11].text_content()
+        cells = self.html.xpath('td[@data-stat="drb"]')
+
+        if len(cells) > 0:
+            return cells[0].text_content()
+
+        return ''
 
     @property
     def assists(self):
-        return self.html[13].text_content()
+        cells = self.html.xpath('td[@data-stat="ast"]')
+
+        if len(cells) > 0:
+            return cells[0].text_content()
+
+        return ''
 
     @property
     def steals(self):
-        return self.html[14].text_content()
+        cells = self.html.xpath('td[@data-stat="stl"]')
+
+        if len(cells) > 0:
+            return cells[0].text_content()
+
+        return ''
 
     @property
     def blocks(self):
-        return self.html[15].text_content()
+        cells = self.html.xpath('td[@data-stat="blk"]')
+
+        if len(cells) > 0:
+            return cells[0].text_content()
+
+        return ''
 
     @property
     def turnovers(self):
-        return self.html[16].text_content()
+        cells = self.html.xpath('td[@data-stat="tov"]')
+
+        if len(cells) > 0:
+            return cells[0].text_content()
+
+        return ''
 
     @property
     def personal_fouls(self):
-        return self.html[17].text_content()
+        cells = self.html.xpath('td[@data-stat="pf"]')
+
+        if len(cells) > 0:
+            return cells[0].text_content()
+
+        return ''
 
     @property
     def points(self):
-        return self.html[18].text_content()
+        cells = self.html.xpath('td[@data-stat="pts"]')
+
+        if len(cells) > 0:
+            return cells[0].text_content()
+
+        return ''
 
 
 class DailyLeadersPage:

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,0 +1,144 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from basketball_reference_web_scraper.html import TeamTotalRow
+
+
+class TestTeamTotalRow(TestCase):
+    def setUp(self):
+        self.html = MagicMock()
+
+    def test_minutes_played_when_cells_exist(self):
+        cell = MagicMock(text_content=MagicMock(return_value="some minutes played"))
+        self.html.xpath = MagicMock(return_value=[cell])
+        self.assertEqual(TeamTotalRow(html=self.html).minutes_played, "some minutes played")
+
+    def test_minutes_played_is_empty_string_when_cells_do_not_exist(self):
+        self.html.xpath = MagicMock(return_value=[])
+        self.assertEqual(TeamTotalRow(html=self.html).minutes_played, '')
+
+    def test_made_field_goals_when_cells_exist(self):
+        cell = MagicMock(text_content=MagicMock(return_value="some made field goals"))
+        self.html.xpath = MagicMock(return_value=[cell])
+        self.assertEqual(TeamTotalRow(html=self.html).made_field_goals, "some made field goals")
+
+    def test_made_field_goals_is_empty_string_when_cells_do_not_exist(self):
+        self.html.xpath = MagicMock(return_value=[])
+        self.assertEqual(TeamTotalRow(html=self.html).made_field_goals, '')
+
+    def test_attempted_field_goals_when_cells_exist(self):
+        cell = MagicMock(text_content=MagicMock(return_value="some attempted field goals"))
+        self.html.xpath = MagicMock(return_value=[cell])
+        self.assertEqual(TeamTotalRow(html=self.html).attempted_field_goals, "some attempted field goals")
+
+    def test_attempted_field_goals_is_empty_string_when_cells_do_not_exist(self):
+        self.html.xpath = MagicMock(return_value=[])
+        self.assertEqual(TeamTotalRow(html=self.html).attempted_field_goals, '')
+
+    def test_made_three_point_field_goals_when_cells_exist(self):
+        cell = MagicMock(text_content=MagicMock(return_value="some made three point field goals"))
+        self.html.xpath = MagicMock(return_value=[cell])
+        self.assertEqual(TeamTotalRow(html=self.html).made_three_point_field_goals, "some made three point field goals")
+
+    def test_made_three_point_field_goals_is_empty_string_when_cells_do_not_exist(self):
+        self.html.xpath = MagicMock(return_value=[])
+        self.assertEqual(TeamTotalRow(html=self.html).made_three_point_field_goals, '')
+
+    def test_attempted_three_point_field_goals_when_cells_exist(self):
+        cell = MagicMock(text_content=MagicMock(return_value="some attempted three point field goals"))
+        self.html.xpath = MagicMock(return_value=[cell])
+        self.assertEqual(TeamTotalRow(html=self.html).attempted_free_throws, "some attempted three point field goals")
+
+    def test_attempted_three_point_field_goals_is_empty_string_when_cells_do_not_exist(self):
+        self.html.xpath = MagicMock(return_value=[])
+        self.assertEqual(TeamTotalRow(html=self.html).attempted_three_point_field_goals, '')
+
+    def test_made_free_throws(self):
+        cell = MagicMock(text_content=MagicMock(return_value="some made free throws"))
+        self.html.xpath = MagicMock(return_value=[cell])
+        self.assertEqual(TeamTotalRow(html=self.html).made_free_throws, "some made free throws")
+
+    def test_made_free_throws_is_empty_string_when_cells_do_not_exist(self):
+        self.html.xpath = MagicMock(return_value=[])
+        self.assertEqual(TeamTotalRow(html=self.html).made_free_throws, '')
+
+    def test_attempted_free_throws(self):
+        cell = MagicMock(text_content=MagicMock(return_value="some attempted free throws"))
+        self.html.xpath = MagicMock(return_value=[cell])
+        self.assertEqual(TeamTotalRow(html=self.html).attempted_free_throws, "some attempted free throws")
+
+    def test_attempted_free_throws_is_empty_string_when_cells_do_not_exist(self):
+        self.html.xpath = MagicMock(return_value=[])
+        self.assertEqual(TeamTotalRow(html=self.html).attempted_free_throws, '')
+
+    def test_offensive_rebounds(self):
+        cell = MagicMock(text_content=MagicMock(return_value="some offensive rebounds"))
+        self.html.xpath = MagicMock(return_value=[cell])
+        self.assertEqual(TeamTotalRow(html=self.html).offensive_rebounds, "some offensive rebounds")
+
+    def test_offensive_rebounds_is_empty_string_when_cells_do_not_exist(self):
+        self.html.xpath = MagicMock(return_value=[])
+        self.assertEqual(TeamTotalRow(html=self.html).offensive_rebounds, '')
+
+    def test_defensive_rebounds(self):
+        cell = MagicMock(text_content=MagicMock(return_value="some defensive rebounds"))
+        self.html.xpath = MagicMock(return_value=[cell])
+        self.assertEqual(TeamTotalRow(html=self.html).defensive_rebounds, "some defensive rebounds")
+
+    def test_defensive_rebounds_is_empty_string_when_cells_do_not_exist(self):
+        self.html.xpath = MagicMock(return_value=[])
+        self.assertEqual(TeamTotalRow(html=self.html).defensive_rebounds, '')
+
+    def test_assists(self):
+        cell = MagicMock(text_content=MagicMock(return_value="some assists"))
+        self.html.xpath = MagicMock(return_value=[cell])
+        self.assertEqual(TeamTotalRow(html=self.html).assists, "some assists")
+
+    def test_assists_is_empty_string_when_cells_do_not_exist(self):
+        self.html.xpath = MagicMock(return_value=[])
+        self.assertEqual(TeamTotalRow(html=self.html).assists, '')
+
+    def test_steals(self):
+        cell = MagicMock(text_content=MagicMock(return_value="some steals"))
+        self.html.xpath = MagicMock(return_value=[cell])
+        self.assertEqual(TeamTotalRow(html=self.html).steals, "some steals")
+
+    def test_steals_is_empty_string_when_cells_do_not_exist(self):
+        self.html.xpath = MagicMock(return_value=[])
+        self.assertEqual(TeamTotalRow(html=self.html).steals, '')
+
+    def test_blocks(self):
+        cell = MagicMock(text_content=MagicMock(return_value="some blocks"))
+        self.html.xpath = MagicMock(return_value=[cell])
+        self.assertEqual(TeamTotalRow(html=self.html).blocks, "some blocks")
+
+    def test_blocks_is_empty_string_when_cells_do_not_exist(self):
+        self.html.xpath = MagicMock(return_value=[])
+        self.assertEqual(TeamTotalRow(html=self.html).blocks, '')
+
+    def test_turnovers(self):
+        cell = MagicMock(text_content=MagicMock(return_value="some turnovers"))
+        self.html.xpath = MagicMock(return_value=[cell])
+        self.assertEqual(TeamTotalRow(html=self.html).turnovers, "some turnovers")
+
+    def test_turnovers_is_empty_string_when_cells_do_not_exist(self):
+        self.html.xpath = MagicMock(return_value=[])
+        self.assertEqual(TeamTotalRow(html=self.html).turnovers, '')
+
+    def test_personal_fouls(self):
+        cell = MagicMock(text_content=MagicMock(return_value="some personal fouls"))
+        self.html.xpath = MagicMock(return_value=[cell])
+        self.assertEqual(TeamTotalRow(html=self.html).personal_fouls, "some personal fouls")
+
+    def test_personal_fouls_is_empty_string_when_cells_do_not_exist(self):
+        self.html.xpath = MagicMock(return_value=[])
+        self.assertEqual(TeamTotalRow(html=self.html).personal_fouls, '')
+
+    def test_points(self):
+        cell = MagicMock(text_content=MagicMock(return_value="some points"))
+        self.html.xpath = MagicMock(return_value=[cell])
+        self.assertEqual(TeamTotalRow(html=self.html).points, "some points")
+
+    def test_points_is_empty_string_when_cells_do_not_exist(self):
+        self.html.xpath = MagicMock(return_value=[])
+        self.assertEqual(TeamTotalRow(html=self.html).points, '')


### PR DESCRIPTION
### Summary

Refactor `TeamTotalRow` class to use `data-stat` property values to parse correct column cell instead of relying on column order.

Related to #127 