### PR TITLE
Migrate player box scores to use a parser service and an http service

### DIFF
--- a/basketball_reference_web_scraper/client.py
+++ b/basketball_reference_web_scraper/client.py
@@ -1,6 +1,8 @@
 import requests
 
 from basketball_reference_web_scraper import http_client
+from basketball_reference_web_scraper.http_service import HTTPService
+from basketball_reference_web_scraper.parser_service import ParserService
 from basketball_reference_web_scraper.errors import InvalidSeason, InvalidDate, InvalidPlayerAndSeason
 from basketball_reference_web_scraper.output import output
 from basketball_reference_web_scraper.writers import CSVWriter, RowFormatter, \
@@ -12,7 +14,8 @@ from basketball_reference_web_scraper.writers import CSVWriter, RowFormatter, \
 def player_box_scores(day, month, year, output_type=None, output_file_path=None, output_write_option=None,
                       json_options=None):
     try:
-        values = http_client.player_box_scores(day=day, month=month, year=year)
+        http_service = HTTPService(parser=ParserService())
+        values = http_service.player_box_scores(day=day, month=month, year=year)
     except requests.exceptions.HTTPError as http_error:
         if http_error.response.status_code == requests.codes.not_found:
             raise InvalidDate(day=day, month=month, year=year)

--- a/basketball_reference_web_scraper/http_client.py
+++ b/basketball_reference_web_scraper/http_client.py
@@ -4,13 +4,13 @@ from lxml import html
 from basketball_reference_web_scraper.data import TEAM_TO_TEAM_ABBREVIATION, TEAM_ABBREVIATIONS_TO_TEAM, TeamTotal, \
     LOCATION_ABBREVIATIONS_TO_POSITION, OUTCOME_ABBREVIATIONS_TO_OUTCOME, TEAM_NAME_TO_TEAM, \
     POSITION_ABBREVIATIONS_TO_POSITION, LEAGUE_ABBREVIATIONS_TO_LEAGUE, PlayerData
-from basketball_reference_web_scraper.errors import InvalidDate, InvalidPlayerAndSeason
-from basketball_reference_web_scraper.html import PlayerSeasonTotalTable, BoxScoresPage, DailyLeadersPage, \
+from basketball_reference_web_scraper.errors import InvalidPlayerAndSeason
+from basketball_reference_web_scraper.html import PlayerSeasonTotalTable, BoxScoresPage, \
     PlayerAdvancedSeasonTotalsTable, PlayByPlayPage, DailyBoxScoresPage, SchedulePage, PlayerSeasonBoxScoresPage, \
     SearchPage, PlayerPage
 from basketball_reference_web_scraper.parsers import PositionAbbreviationParser, TeamAbbreviationParser, \
     PlayerSeasonTotalsParser, TeamTotalsParser, LocationAbbreviationParser, OutcomeAbbreviationParser, \
-    SecondsPlayedParser, PlayerBoxScoresParser, PlayerAdvancedSeasonTotalsParser, PeriodDetailsParser, \
+    SecondsPlayedParser, PlayerAdvancedSeasonTotalsParser, PeriodDetailsParser, \
     PeriodTimestampParser, ScoresParser, PlayByPlaysParser, TeamNameParser, ScheduledStartTimeParser, \
     ScheduledGamesParser, PlayerBoxScoreOutcomeParser, PlayerSeasonBoxScoresParser, SearchResultNameParser, \
     ResourceLocationParser, SearchResultsParser, LeagueAbbreviationParser, PlayerDataParser
@@ -19,37 +19,6 @@ BASE_URL = 'https://www.basketball-reference.com'
 PLAY_BY_PLAY_TIMESTAMP_FORMAT = "%M:%S.%f"
 PLAY_BY_PLAY_SCORES_REGEX = "(?P<away_team_score>[0-9]+)-(?P<home_team_score>[0-9]+)"
 SEARCH_RESULT_RESOURCE_LOCATION_REGEX = '(https?:\/\/www\.basketball-reference\.com\/)?(?P<resource_type>.+?(?=\/)).*\/(?P<resource_identifier>.+).html'
-
-
-def player_box_scores(day, month, year):
-    url = '{BASE_URL}/friv/dailyleaders.cgi?month={month}&day={day}&year={year}'.format(
-        BASE_URL=BASE_URL,
-        day=day,
-        month=month,
-        year=year
-    )
-
-    response = requests.get(url=url, allow_redirects=False)
-
-    response.raise_for_status()
-
-    if response.status_code == requests.codes.ok:
-        page = DailyLeadersPage(html=html.fromstring(response.content))
-        box_score_parser = PlayerBoxScoresParser(
-            team_abbreviation_parser=TeamAbbreviationParser(
-                abbreviations_to_teams=TEAM_ABBREVIATIONS_TO_TEAM
-            ),
-            location_abbreviation_parser=LocationAbbreviationParser(
-                abbreviations_to_locations=LOCATION_ABBREVIATIONS_TO_POSITION
-            ),
-            outcome_abbreviation_parser=OutcomeAbbreviationParser(
-                abbreviations_to_outcomes=OUTCOME_ABBREVIATIONS_TO_OUTCOME
-            ),
-            seconds_played_parser=SecondsPlayedParser(),
-        )
-        return box_score_parser.parse(page.daily_leaders)
-
-    raise InvalidDate(day=day, month=month, year=year)
 
 
 def regular_season_player_box_scores(player_identifier, season_end_year):

--- a/basketball_reference_web_scraper/http_service.py
+++ b/basketball_reference_web_scraper/http_service.py
@@ -1,0 +1,30 @@
+import requests
+from lxml import html
+
+from basketball_reference_web_scraper.errors import InvalidDate
+from basketball_reference_web_scraper.html import DailyLeadersPage
+
+
+class HTTPService:
+    BASE_URL = 'https://www.basketball-reference.com'
+
+    def __init__(self, parser):
+        self.parser = parser
+
+    def player_box_scores(self, day, month, year):
+        url = '{BASE_URL}/friv/dailyleaders.cgi?month={month}&day={day}&year={year}'.format(
+            BASE_URL=HTTPService.BASE_URL,
+            day=day,
+            month=month,
+            year=year
+        )
+
+        response = requests.get(url=url, allow_redirects=False)
+
+        response.raise_for_status()
+
+        if response.status_code == requests.codes.ok:
+            page = DailyLeadersPage(html=html.fromstring(response.content))
+            return self.parser.parse_player_box_scores(box_scores=page.daily_leaders)
+
+        raise InvalidDate(day=day, month=month, year=year)

--- a/basketball_reference_web_scraper/parser_service.py
+++ b/basketball_reference_web_scraper/parser_service.py
@@ -1,0 +1,27 @@
+from basketball_reference_web_scraper.data import TEAM_TO_TEAM_ABBREVIATION, TEAM_ABBREVIATIONS_TO_TEAM, TeamTotal, \
+    LOCATION_ABBREVIATIONS_TO_POSITION, OUTCOME_ABBREVIATIONS_TO_OUTCOME, TEAM_NAME_TO_TEAM, \
+    POSITION_ABBREVIATIONS_TO_POSITION, LEAGUE_ABBREVIATIONS_TO_LEAGUE, PlayerData
+from basketball_reference_web_scraper.parsers import PositionAbbreviationParser, TeamAbbreviationParser, \
+    PlayerSeasonTotalsParser, TeamTotalsParser, LocationAbbreviationParser, OutcomeAbbreviationParser, \
+    SecondsPlayedParser, PlayerBoxScoresParser, PlayerAdvancedSeasonTotalsParser, PeriodDetailsParser, \
+    PeriodTimestampParser, ScoresParser, PlayByPlaysParser, TeamNameParser, ScheduledStartTimeParser, \
+    ScheduledGamesParser, PlayerBoxScoreOutcomeParser, PlayerSeasonBoxScoresParser, SearchResultNameParser, \
+    ResourceLocationParser, SearchResultsParser, LeagueAbbreviationParser, PlayerDataParser
+
+
+class ParserService:
+    def __init__(self):
+        self.team_abbreviation_parser = TeamAbbreviationParser(abbreviations_to_teams=TEAM_ABBREVIATIONS_TO_TEAM)
+        self.location_abbreviation_parser = LocationAbbreviationParser(abbreviations_to_locations=LOCATION_ABBREVIATIONS_TO_POSITION)
+        self.outcome_abbreviation_parser = OutcomeAbbreviationParser(abbreviations_to_outcomes=OUTCOME_ABBREVIATIONS_TO_OUTCOME)
+        self.seconds_played_parser = SecondsPlayedParser()
+
+        self.player_box_scores_parser = PlayerBoxScoresParser(
+            team_abbreviation_parser=self.team_abbreviation_parser,
+            location_abbreviation_parser=self.location_abbreviation_parser,
+            outcome_abbreviation_parser=self.outcome_abbreviation_parser,
+            seconds_played_parser=self.seconds_played_parser
+        )
+
+    def parse_player_box_scores(self, box_scores):
+        return self.player_box_scores_parser.parse(box_scores=box_scores)

--- a/tests/integration/client/test_player_box_scores.py
+++ b/tests/integration/client/test_player_box_scores.py
@@ -1,7 +1,5 @@
-from unittest import TestCase, mock
 import os
-
-from requests import HTTPError, codes
+from unittest import TestCase
 
 from basketball_reference_web_scraper.client import player_box_scores
 from basketball_reference_web_scraper.data import OutputType, OutputWriteOption
@@ -23,7 +21,7 @@ class TestPlayerBoxScores(TestCase):
     def test_get_box_scores_from_2001(self):
         output_file_path = os.path.join(
             os.path.dirname(__file__),
-            "./output/2003_10_29_TOR_pbp.csv",
+            "../output/2003_10_29_TOR_pbp.csv",
         )
         player_box_scores(
             day=1, month=1, year=2001,
@@ -35,13 +33,3 @@ class TestPlayerBoxScores(TestCase):
             "Date with year set to baz, month set to bar, and day set to foo is invalid",
             player_box_scores,
             day="foo", month="bar", year="baz")
-
-    @mock.patch("basketball_reference_web_scraper.client.http_client")
-    def test_raises_invalid_date_for_404_response(self, mocked_http_client):
-        mocked_http_client.player_box_scores.side_effect = HTTPError(response=mock.Mock(status_code=codes.not_found))
-        self.assertRaises(InvalidDate, player_box_scores, day=1, month=1, year=2018)
-
-    @mock.patch("basketball_reference_web_scraper.client.http_client")
-    def test_raises_non_404_http_error(self, mocked_http_client):
-        mocked_http_client.player_box_scores.side_effect = HTTPError(response=mock.Mock(status_code=codes.server_error))
-        self.assertRaises(HTTPError, player_box_scores, day=1, month=1, year=2018)

--- a/tests/unit/client/test_player_box_scores.py
+++ b/tests/unit/client/test_player_box_scores.py
@@ -1,0 +1,19 @@
+from unittest import TestCase, mock
+
+from requests import HTTPError, codes
+
+from basketball_reference_web_scraper.client import player_box_scores
+from basketball_reference_web_scraper.errors import InvalidDate
+from basketball_reference_web_scraper.http_service import HTTPService
+
+
+class TestPlayerBoxScores(TestCase):
+    @mock.patch.object(HTTPService, 'player_box_scores')
+    def test_raises_invalid_date_for_404_response(self, mocked_player_box_scores):
+        mocked_player_box_scores.side_effect = HTTPError(response=mock.Mock(status_code=codes.not_found))
+        self.assertRaises(InvalidDate, player_box_scores, day=1, month=1, year=2018)
+
+    @mock.patch.object(HTTPService, 'player_box_scores')
+    def test_raises_non_404_http_error(self, mocked_player_box_scores):
+        mocked_player_box_scores.side_effect = HTTPError(response=mock.Mock(status_code=codes.server_error))
+        self.assertRaises(HTTPError, player_box_scores, day=1, month=1, year=2018)

--- a/tests/unit/test_http_service.py
+++ b/tests/unit/test_http_service.py
@@ -2,11 +2,11 @@ from unittest import TestCase, mock
 
 from requests import codes
 
-from basketball_reference_web_scraper import http_client
 from basketball_reference_web_scraper.errors import InvalidDate
+from basketball_reference_web_scraper.http_service import HTTPService
 
 
-class TestHttpClient(TestCase):
+class TestHTTPService(TestCase):
     @mock.patch("requests.get")
     def test_player_box_scores_raises_invalid_date_for_300_response(self, mocked_get):
         response = mock.Mock(status_code=codes.multiple_choices)
@@ -14,5 +14,5 @@ class TestHttpClient(TestCase):
         self.assertRaisesRegex(
             InvalidDate,
             "Date with year set to 2018, month set to 1, and day set to 1 is invalid",
-            http_client.player_box_scores,
+            HTTPService(parser=mock.MagicMock()).player_box_scores,
             day=1, month=1, year=2018)


### PR DESCRIPTION
### Summary

Create a `ParserService` and an `HTTPService` that will serve to  split apart the existing code that lives in `http_client` which currently combines some of the parsing logic (mostly the instantiation of various parsers) with the HTTP fetching logic.