### PR TITLE
Check if league is none in case where player did not participate for a given season

### DIFF
--- a/basketball_reference_web_scraper/http_service.py
+++ b/basketball_reference_web_scraper/http_service.py
@@ -194,7 +194,11 @@ class HTTPService:
             data = PlayerData(
                 name=page.name,
                 resource_location=response.url,
-                league_abbreviations=set([row.league_abbreviation for row in page.totals_table.rows])
+                league_abbreviations=set([
+                    row.league_abbreviation
+                    for row in page.totals_table.rows
+                    if row.league_abbreviation is not None
+                ])
             )
             player_results += [self.parser.parse_player_data(player=data)]
 

--- a/tests/integration/client/test_search.py
+++ b/tests/integration/client/test_search.py
@@ -11,6 +11,49 @@ class TestSearchInMemory(TestCase):
         results = client.search(term="ja")
         self.assertGreaterEqual(498, len(results["players"]))
 
+    def test_search_alonzo_mourning(self):
+        results = client.search(term="Alonzo Mourning")
+        self.assertEqual(
+            [
+                {
+                    "name": "Alonzo Mourning",
+                    "identifier": "mournal01",
+                    "leagues": {League.NATIONAL_BASKETBALL_ASSOCIATION}
+                }
+            ],
+            results["players"]
+        )
+
+    def test_search_alonz(self):
+        results = client.search(term="Alonz")
+        self.assertGreaterEqual(6, results["players"])
+
+    def test_search_dominique_wilkins(self):
+        results = client.search(term="Dominique Wilkins")
+        self.assertEqual(
+            [
+                {
+                    "name": "Dominique Wilkins",
+                    "identifier": "wilkido01",
+                    "leagues": {League.NATIONAL_BASKETBALL_ASSOCIATION}
+                }
+            ],
+            results["players"]
+        )
+
+    def test_search_rick_barry(self):
+        results = client.search(term="Rick Barry")
+        self.assertEqual(
+            [
+                {
+                    "name": "Rick Barry",
+                    "identifier": "barryri01",
+                    "leagues": {League.NATIONAL_BASKETBALL_ASSOCIATION, League.AMERICAN_BASKETBALL_ASSOCIATION}
+                }
+            ],
+            results["players"]
+        )
+
     def test_search_jaebaebae(self):
         results = client.search(term="jaebaebae")
         self.assertListEqual([], results["players"])

--- a/tests/integration/client/test_search.py
+++ b/tests/integration/client/test_search.py
@@ -26,7 +26,7 @@ class TestSearchInMemory(TestCase):
 
     def test_search_alonz(self):
         results = client.search(term="Alonz")
-        self.assertGreaterEqual(6, results["players"])
+        self.assertGreaterEqual(6, len(results["players"]))
 
     def test_search_dominique_wilkins(self):
         results = client.search(term="Dominique Wilkins")


### PR DESCRIPTION
Resolves #184 

In each of the cases mentioned on the issue, the player did not participate for a given season.

In Alonzo Mourning's case it was due to illness

<img width="1162" alt="image" src="https://user-images.githubusercontent.com/8136030/83691823-d55a7300-a5c0-11ea-928b-e9c0311c880d.png">

In Dominique Wilkins' case it was due to playing in other professional leagues

<img width="1067" alt="image" src="https://user-images.githubusercontent.com/8136030/83691854-e60ae900-a5c0-11ea-8f5b-ecc1a0478772.png">

And in Rick Barry's case it was for legal reasons

<img width="1111" alt="image" src="https://user-images.githubusercontent.com/8136030/83691927-0175f400-a5c1-11ea-9b25-1670b5fa6d83.png">

So when parsing leagues from a player's page (when search redirects to player's page when they are only matching result) check to see if league is `None`.