### PR TITLE
o-rating and d-rating

### DIFF
--- a/basketball_reference_web_scraper/data.py
+++ b/basketball_reference_web_scraper/data.py
@@ -226,9 +226,18 @@ LEAGUE_ABBREVIATIONS_TO_LEAGUE = {
 
 
 class TeamTotal:
-    def __init__(self, team_abbreviation, totals):
+    def __init__(self, team_abbreviation, totals, advanced_totals):
         self.team_abbreviation = team_abbreviation
         self.totals = totals
+        self.advanced_totals = advanced_totals
+
+    @property
+    def offensive_rating(self):
+        return self.advanced_totals.offensive_rating
+
+    @property
+    def defensive_rating(self):
+        return self.advanced_totals.defensive_rating
 
     @property
     def minutes_played(self):

--- a/basketball_reference_web_scraper/html.py
+++ b/basketball_reference_web_scraper/html.py
@@ -601,6 +601,14 @@ class BoxScoresPage:
             if table.has_basic_statistics is True
         ]
 
+    @property
+    def advanced_statistics_tables(self):
+        return [
+            table
+            for table in self.statistics_tables
+            if table.has_advanced_statistics is True
+        ]
+
 
 class StatisticsTable:
     def __init__(self, html):
@@ -609,6 +617,11 @@ class StatisticsTable:
     @property
     def has_basic_statistics(self):
         return 'game-basic' in self.html.attrib["id"]
+
+
+    @property
+    def has_advanced_statistics(self):
+        return 'game-advanced' in self.html.attrib["id"]
 
     @property
     def team_abbreviation(self):
@@ -624,6 +637,24 @@ class StatisticsTable:
             return BasicBoxScoreRow(html=footers[0])
 
         return None
+
+    @property
+    def advanced_team_totals(self):
+        # Team totals are stored as table footers
+        return AdvancedTeamTotalRow(self.html.xpath('tfoot/tr/td'))
+
+
+class AdvancedTeamTotalRow:
+    def __init__(self, html):
+        self.html = html
+
+    @property
+    def offensive_rating(self):
+        return self.html[13].text_content()
+
+    @property
+    def defensive_rating(self):
+        return self.html[14].text_content()
 
 
 class DailyLeadersPage:

--- a/basketball_reference_web_scraper/http_service.py
+++ b/basketball_reference_web_scraper/http_service.py
@@ -169,10 +169,14 @@ class HTTPService:
         response.raise_for_status()
 
         page = BoxScoresPage(html.fromstring(response.content))
-        combined_team_totals = [
-            TeamTotal(team_abbreviation=table.team_abbreviation, totals=table.team_totals)
-            for table in page.basic_statistics_tables
-        ]
+        combined_team_totals = []
+        for i in range(len(page.basic_statistics_tables)):
+            table = page.basic_statistics_tables[i]
+            adv_table = page.advanced_statistics_tables[i]
+            combined_team_totals.append(
+                TeamTotal(team_abbreviation=table.team_abbreviation,
+                          totals=table.team_totals,
+                          advanced_totals=adv_table.advanced_team_totals))
 
         return self.parser.parse_team_totals(
             first_team_totals=combined_team_totals[0],

--- a/basketball_reference_web_scraper/parsers.py
+++ b/basketball_reference_web_scraper/parsers.py
@@ -421,6 +421,8 @@ class TeamTotalsParser:
             "turnovers": str_to_int(team_totals.turnovers),
             "personal_fouls": str_to_int(team_totals.personal_fouls),
             "points": str_to_int(team_totals.points),
+            "offensive_rating": str_to_float(total.offensive_rating),
+            "defensive_rating": str_to_float(total.defensive_rating),
         }
 
 

--- a/basketball_reference_web_scraper/parsers.py
+++ b/basketball_reference_web_scraper/parsers.py
@@ -421,8 +421,8 @@ class TeamTotalsParser:
             "turnovers": str_to_int(team_totals.turnovers),
             "personal_fouls": str_to_int(team_totals.personal_fouls),
             "points": str_to_int(team_totals.points),
-            "offensive_rating": str_to_float(total.offensive_rating),
-            "defensive_rating": str_to_float(total.defensive_rating),
+            "offensive_rating": str_to_float(team_totals.offensive_rating),
+            "defensive_rating": str_to_float(team_totals.defensive_rating),
         }
 
 


### PR DESCRIPTION
Hi. I was looking for a way to gather per-game O and D ratings and with the patch your tool seems to do the trick!

It would also be pretty easy to add support for the other "advanced" stats using this approach.

FWIW I want this for an idea I have to calculate opponent-adjusted ratings to do things like compensate for strength of schedule or reduce the amount of credit given for running up the score on the worst teams.