### PR TITLE
Add plus_minus field to player_box_scores query

### DIFF
--- a/basketball_reference_web_scraper/output/columns.py
+++ b/basketball_reference_web_scraper/output/columns.py
@@ -20,6 +20,7 @@ SHARED_COLUMN_NAMES = [
     "blocks",
     "turnovers",
     "personal_fouls",
+    "plus_minus",
     "game_score",
 ]
 

--- a/basketball_reference_web_scraper/output/columns.py
+++ b/basketball_reference_web_scraper/output/columns.py
@@ -20,11 +20,10 @@ SHARED_COLUMN_NAMES = [
     "blocks",
     "turnovers",
     "personal_fouls",
-    "plus_minus",
     "game_score",
 ]
 
-BOX_SCORE_COLUMN_NAMES = ["slug", "name"] + SHARED_COLUMN_NAMES
+BOX_SCORE_COLUMN_NAMES = ["slug", "name"] + SHARED_COLUMN_NAMES + ["plus_minus"]
 
 PLAYER_SEASON_BOX_SCORE_COLUMN_NAMES = ["active", "date", "points_scored", "plus_minus"] + SHARED_COLUMN_NAMES
 


### PR DESCRIPTION
I see no reason why this should not be included. Currently, it is the only field in the daily stats leaders page that is not included and cannot be calculated from the other included fields. Resolves issue #280.