### PR TITLE
Update season schedule parser to return ET time, instead of UTC

### DIFF
--- a/basketball_reference_web_scraper/parsers.py
+++ b/basketball_reference_web_scraper/parsers.py
@@ -225,7 +225,7 @@ class ScheduledStartTimeParser:
         # All basketball reference times seem to be in Eastern
         est = pytz.timezone("US/Eastern")
         localized_start_time = est.localize(start_time)
-        return localized_start_time.astimezone(self.time_zone)
+        return localized_start_time
 
 
 class SearchResultNameParser:


### PR DESCRIPTION
Updating season schedules to return ET time instead of UTC. This makes sense because when using client functions that query with a game date (year/month/day), they are checking the ET times on Basketball Reference.

As a more concrete example:
Currently - if I first query for a list of games in 2024, then use those dates to query box scores, I would miss games unless I convert all the returned datetimes to ET

After this update - Users will not have to convert the datetimes returned from the season schedule query