### PR TITLE
Fix play_by_play crash when parsing 'Time' header rows

### DIFF
--- a/basketball_reference_web_scraper/html.py
+++ b/basketball_reference_web_scraper/html.py
@@ -1072,7 +1072,9 @@ class PlayByPlayRow:
         return not self.is_start_of_period \
             and 2 <= len(self.html) \
             and self.html[1].get('colspan') != '5' \
+            and self.timestamp != 'Time' \
             and self.timestamp_cell.get('aria-label') != 'Time'
+
 
 
 class DailyBoxScoresPage:

--- a/tests/test_playbyplay_time_header.py
+++ b/tests/test_playbyplay_time_header.py
@@ -1,0 +1,7 @@
+from lxml import html as lxml_html
+from basketball_reference_web_scraper.html import PlayByPlayRow
+
+def test_play_by_play_row_ignores_time_header_row():
+    tr = lxml_html.fromstring("<tr><td>Time</td><td></td></tr>")
+    row = PlayByPlayRow(html=tr)
+    assert row.has_play_by_play_data is False


### PR DESCRIPTION
The `play_by_play()` function crashes with: ValueError: time data 'Time' does not match format '%M:%S.%f'
-This happens when Basketball Reference includes header rows with timestamp text "Time" but without the `aria-label="Time"` attribute.

Added an additional check in `has_play_by_play_data()` to skip rows where `timestamp == 'Time'`.

Fixing #229 
- Added regression test in `tests/test_playbyplay_time_header.py`
- Verified all play-by-play integration tests still pass
- Manually tested with real game data
