### PR TITLE
feat: support custom HTTP settings (headers, proxies, timeout)

### DIFF
--- a/basketball_reference_web_scraper/client.py
+++ b/basketball_reference_web_scraper/client.py
@@ -14,9 +14,9 @@ from basketball_reference_web_scraper.parser_service import ParserService
 
 
 def standings(season_end_year, output_type=None, output_file_path=None, output_write_option=None,
-              json_options=None):
+              json_options=None, headers=None, proxies=None, timeout=None):
     try:
-        http_service = HTTPService(parser=ParserService())
+        http_service = HTTPService(parser=ParserService(), headers=headers, proxies=proxies, timeout=timeout)
         values = http_service.standings(season_end_year=season_end_year)
     except requests.exceptions.HTTPError as http_error:
         if http_error.response.status_code == requests.codes.not_found:
@@ -37,9 +37,9 @@ def standings(season_end_year, output_type=None, output_file_path=None, output_w
 
 
 def player_box_scores(day, month, year, output_type=None, output_file_path=None, output_write_option=None,
-                      json_options=None):
+                      json_options=None, headers=None, proxies=None, timeout=None):
     try:
-        http_service = HTTPService(parser=ParserService())
+        http_service = HTTPService(parser=ParserService(), headers=headers, proxies=proxies, timeout=timeout)
         values = http_service.player_box_scores(day=day, month=month, year=year)
     except requests.exceptions.HTTPError as http_error:
         if http_error.response.status_code == requests.codes.not_found:
@@ -61,9 +61,10 @@ def player_box_scores(day, month, year, output_type=None, output_file_path=None,
 
 
 def regular_season_player_box_scores(player_identifier, season_end_year, output_type=None, output_file_path=None,
-                                     output_write_option=None, json_options=None, include_inactive_games=False):
+                                     output_write_option=None, json_options=None, include_inactive_games=False,
+                                     headers=None, proxies=None, timeout=None):
     try:
-        http_service = HTTPService(parser=ParserService())
+        http_service = HTTPService(parser=ParserService(), headers=headers, proxies=proxies, timeout=timeout)
         values = http_service.regular_season_player_box_scores(
             player_identifier=player_identifier,
             season_end_year=season_end_year,
@@ -89,9 +90,10 @@ def regular_season_player_box_scores(player_identifier, season_end_year, output_
 
 
 def playoff_player_box_scores(player_identifier, season_end_year, output_type=None, output_file_path=None,
-                              output_write_option=None, json_options=None, include_inactive_games=False):
+                              output_write_option=None, json_options=None, include_inactive_games=False,
+                              headers=None, proxies=None, timeout=None):
     try:
-        http_service = HTTPService(parser=ParserService())
+        http_service = HTTPService(parser=ParserService(), headers=headers, proxies=proxies, timeout=timeout)
         values = http_service.playoff_player_box_scores(
             player_identifier=player_identifier,
             season_end_year=season_end_year,
@@ -118,9 +120,9 @@ def playoff_player_box_scores(player_identifier, season_end_year, output_type=No
 
 
 def season_schedule(season_end_year, output_type=None, output_file_path=None, output_write_option=None,
-                    json_options=None):
+                    json_options=None, headers=None, proxies=None, timeout=None):
     try:
-        http_service = HTTPService(parser=ParserService())
+        http_service = HTTPService(parser=ParserService(), headers=headers, proxies=proxies, timeout=timeout)
         values = http_service.season_schedule(season_end_year=season_end_year)
     except requests.exceptions.HTTPError as http_error:
         # https://github.com/requests/requests/blob/master/requests/status_codes.py#L58
@@ -142,9 +144,9 @@ def season_schedule(season_end_year, output_type=None, output_file_path=None, ou
 
 
 def players_season_totals(season_end_year, output_type=None, output_file_path=None, output_write_option=None,
-                          json_options=None):
+                          json_options=None, headers=None, proxies=None, timeout=None):
     try:
-        http_service = HTTPService(parser=ParserService())
+        http_service = HTTPService(parser=ParserService(), headers=headers, proxies=proxies, timeout=timeout)
         values = http_service.players_season_totals(season_end_year=season_end_year)
     except requests.exceptions.HTTPError as http_error:
         if http_error.response.status_code == requests.codes.not_found:
@@ -165,9 +167,10 @@ def players_season_totals(season_end_year, output_type=None, output_file_path=No
 
 
 def players_advanced_season_totals(season_end_year, include_combined_values=False, output_type=None,
-                                   output_file_path=None, output_write_option=None, json_options=None):
+                                   output_file_path=None, output_write_option=None, json_options=None,
+                                   headers=None, proxies=None, timeout=None):
     try:
-        http_service = HTTPService(parser=ParserService())
+        http_service = HTTPService(parser=ParserService(), headers=headers, proxies=proxies, timeout=timeout)
         values = http_service.players_advanced_season_totals(
             season_end_year,
             include_combined_values=include_combined_values
@@ -191,9 +194,9 @@ def players_advanced_season_totals(season_end_year, include_combined_values=Fals
 
 
 def team_box_scores(day, month, year, output_type=None, output_file_path=None, output_write_option=None,
-                    json_options=None):
+                    json_options=None, headers=None, proxies=None, timeout=None):
     try:
-        http_service = HTTPService(parser=ParserService())
+        http_service = HTTPService(parser=ParserService(), headers=headers, proxies=proxies, timeout=timeout)
         values = http_service.team_box_scores(day=day, month=month, year=year)
     except requests.exceptions.HTTPError as http_error:
         if http_error.response.status_code == requests.codes.not_found:
@@ -214,9 +217,9 @@ def team_box_scores(day, month, year, output_type=None, output_file_path=None, o
 
 
 def play_by_play(home_team, day, month, year, output_type=None, output_file_path=None, output_write_option=None,
-                 json_options=None):
+                 json_options=None, headers=None, proxies=None, timeout=None):
     try:
-        http_service = HTTPService(parser=ParserService())
+        http_service = HTTPService(parser=ParserService(), headers=headers, proxies=proxies, timeout=timeout)
         values = http_service.play_by_play(home_team=home_team, day=day, month=month, year=year)
     except requests.exceptions.HTTPError as http_error:
         if http_error.response.status_code == requests.codes.not_found:
@@ -236,8 +239,9 @@ def play_by_play(home_team, day, month, year, output_type=None, output_file_path
     return output_service.output(data=values, options=options)
 
 
-def search(term, output_type=None, output_file_path=None, output_write_option=None, json_options=None):
-    http_service = HTTPService(parser=ParserService())
+def search(term, output_type=None, output_file_path=None, output_write_option=None, json_options=None,
+           headers=None, proxies=None, timeout=None):
+    http_service = HTTPService(parser=ParserService(), headers=headers, proxies=proxies, timeout=timeout)
     values = http_service.search(term=term)
     options = OutputOptions.of(
         file_options=FileOptions.of(path=output_file_path, mode=output_write_option),

--- a/basketball_reference_web_scraper/http_service.py
+++ b/basketball_reference_web_scraper/http_service.py
@@ -11,8 +11,21 @@ from basketball_reference_web_scraper.html import DailyLeadersPage, PlayerSeason
 class HTTPService:
     BASE_URL = 'https://www.basketball-reference.com'
 
-    def __init__(self, parser):
+    def __init__(self, parser, headers=None, proxies=None, timeout=None):
         self.parser = parser
+        self.headers = headers
+        self.proxies = proxies
+        self.timeout = timeout
+
+    def _get(self, url, allow_redirects=True, params=None):
+        return requests.get(
+            url=url,
+            allow_redirects=allow_redirects,
+            params=params,
+            headers=self.headers,
+            proxies=self.proxies,
+            timeout=self.timeout,
+        )
 
     def standings(self, season_end_year):
         url = '{BASE_URL}/leagues/NBA_{season_end_year}.html'.format(
@@ -20,7 +33,7 @@ class HTTPService:
             season_end_year=season_end_year,
         )
 
-        response = requests.get(url=url, allow_redirects=False)
+        response = self._get(url=url, allow_redirects=False)
 
         response.raise_for_status()
 
@@ -36,7 +49,7 @@ class HTTPService:
             year=year
         )
 
-        response = requests.get(url=url, allow_redirects=False)
+        response = self._get(url=url, allow_redirects=False)
 
         response.raise_for_status()
 
@@ -58,7 +71,7 @@ class HTTPService:
             season_end_year=season_end_year,
         )
 
-        response = requests.get(url=url, allow_redirects=False)
+        response = self._get(url=url, allow_redirects=False)
         response.raise_for_status()
 
         page = PlayerSeasonBoxScoresPage(html=html.fromstring(response.content))
@@ -79,7 +92,7 @@ class HTTPService:
             season_end_year=season_end_year,
         )
 
-        response = requests.get(url=url, allow_redirects=False)
+        response = self._get(url=url, allow_redirects=False)
         response.raise_for_status()
 
         page = PlayerSeasonBoxScoresPage(html=html.fromstring(response.content))
@@ -96,7 +109,7 @@ class HTTPService:
             BASE_URL=HTTPService.BASE_URL, year=year, month=add_0_if_needed(str(month)), day=add_0_if_needed(str(day)),
             team_abbr=TEAM_TO_TEAM_ABBREVIATION[home_team]
         )
-        response = requests.get(url=url)
+        response = self._get(url=url)
         response.raise_for_status()
 
         page = PlayByPlayPage(html=html.fromstring(response.content))
@@ -113,7 +126,7 @@ class HTTPService:
             season_end_year=season_end_year,
         )
 
-        response = requests.get(url=url)
+        response = self._get(url=url)
 
         response.raise_for_status()
 
@@ -126,7 +139,7 @@ class HTTPService:
             season_end_year=season_end_year,
         )
 
-        response = requests.get(url=url)
+        response = self._get(url=url)
 
         response.raise_for_status()
 
@@ -134,7 +147,7 @@ class HTTPService:
         return self.parser.parse_player_season_totals(totals=table.rows)
 
     def schedule_for_month(self, url):
-        response = requests.get(url=url)
+        response = self._get(url=url)
 
         response.raise_for_status()
 
@@ -147,7 +160,7 @@ class HTTPService:
             season_end_year=season_end_year
         )
 
-        response = requests.get(url=url)
+        response = self._get(url=url)
 
         response.raise_for_status()
 
@@ -164,7 +177,7 @@ class HTTPService:
     def team_box_score(self, game_url_path):
         url = "{BASE_URL}/{game_url_path}".format(BASE_URL=HTTPService.BASE_URL, game_url_path=game_url_path)
 
-        response = requests.get(url=url)
+        response = self._get(url=url)
 
         response.raise_for_status()
 
@@ -182,7 +195,7 @@ class HTTPService:
     def team_box_scores(self, day, month, year):
         url = "{BASE_URL}/boxscores/".format(BASE_URL=HTTPService.BASE_URL)
 
-        response = requests.get(url=url, params={"day": day, "month": month, "year": year})
+        response = self._get(url=url, params={"day": day, "month": month, "year": year})
 
         response.raise_for_status()
 
@@ -195,7 +208,7 @@ class HTTPService:
         ]
 
     def search(self, term):
-        response = requests.get(
+        response = self._get(
             url="{BASE_URL}/search/search.fcgi".format(BASE_URL=HTTPService.BASE_URL),
             params={"search": term}
         )
@@ -210,7 +223,7 @@ class HTTPService:
             player_results += parsed_results["players"]
 
             while page.nba_aba_baa_players_pagination_url is not None:
-                response = requests.get(
+                response = self._get(
                     url="{BASE_URL}/search/{pagination_url}".format(
                         BASE_URL=HTTPService.BASE_URL,
                         pagination_url=page.nba_aba_baa_players_pagination_url

--- a/tests/integration/client/test_custom_http_settings.py
+++ b/tests/integration/client/test_custom_http_settings.py
@@ -1,0 +1,90 @@
+import os
+from unittest import TestCase
+from unittest.mock import patch
+
+import requests_mock
+
+from basketball_reference_web_scraper import client
+from basketball_reference_web_scraper.http_service import HTTPService
+from basketball_reference_web_scraper.parser_service import ParserService
+
+
+class TestCustomHTTPSettings(TestCase):
+    def setUp(self):
+        with open(
+            os.path.join(
+                os.path.dirname(__file__),
+                "../files/players_season_totals/2018.html",
+            ),
+            "r",
+        ) as fixture:
+            self._html = fixture.read()
+        self._url = "https://www.basketball-reference.com/leagues/NBA_2018_totals.html"
+
+    @requests_mock.Mocker()
+    def test_custom_user_agent_is_applied_to_request(self, m):
+        m.get(self._url, text=self._html, status_code=200)
+
+        client.players_season_totals(
+            season_end_year=2018,
+            headers={"User-Agent": "my-custom-user-agent/1.0"},
+        )
+
+        self.assertEqual(
+            "my-custom-user-agent/1.0",
+            m.last_request.headers.get("User-Agent"),
+        )
+
+    @requests_mock.Mocker()
+    def test_custom_header_is_applied_to_request(self, m):
+        m.get(self._url, text=self._html, status_code=200)
+
+        client.players_season_totals(
+            season_end_year=2018,
+            headers={"X-Custom-Header": "custom-value"},
+        )
+
+        self.assertEqual(
+            "custom-value",
+            m.last_request.headers.get("X-Custom-Header"),
+        )
+
+    @requests_mock.Mocker()
+    def test_default_user_agent_is_used_when_no_settings_provided(self, m):
+        m.get(self._url, text=self._html, status_code=200)
+
+        client.players_season_totals(season_end_year=2018)
+
+        self.assertTrue(
+            m.last_request.headers.get("User-Agent", "").startswith("python-requests/"),
+        )
+
+
+class TestHTTPServiceForwardsCustomSettings(TestCase):
+    @patch("basketball_reference_web_scraper.http_service.requests.get")
+    def test_headers_proxies_and_timeout_are_forwarded_to_requests(self, mock_get):
+        headers = {"User-Agent": "my-custom-user-agent/1.0"}
+        proxies = {"https": "https://proxy.example.com:8080"}
+
+        service = HTTPService(
+            parser=ParserService(),
+            headers=headers,
+            proxies=proxies,
+            timeout=12,
+        )
+        service._get(url="https://www.basketball-reference.com/")
+
+        _, kwargs = mock_get.call_args
+        self.assertEqual(headers, kwargs["headers"])
+        self.assertEqual(proxies, kwargs["proxies"])
+        self.assertEqual(12, kwargs["timeout"])
+
+    @patch("basketball_reference_web_scraper.http_service.requests.get")
+    def test_settings_default_to_none_to_preserve_existing_behavior(self, mock_get):
+        service = HTTPService(parser=ParserService())
+        service._get(url="https://www.basketball-reference.com/")
+
+        _, kwargs = mock_get.call_args
+        self.assertIsNone(kwargs["headers"])
+        self.assertIsNone(kwargs["proxies"])
+        self.assertIsNone(kwargs["timeout"])


### PR DESCRIPTION
## Summary

Adds the ability to pass custom HTTP settings — `headers` (e.g. a custom `User-Agent`), `proxies`, and `timeout` — through the client API, as requested in #157.

### Motivation

basketball-reference returns errors for requests sent with the default `python-requests/<version>` User-Agent, which breaks the library in many environments. There is currently no public way to override the outgoing request, so this adds one.

### Changes

- `HTTPService` accepts optional `headers`, `proxies`, and `timeout`, applied via a small `_get` helper that every request method now uses.
- Each `client` function accepts the same optional `headers` / `proxies` / `timeout` and threads them through to `HTTPService`.
- All new parameters are **optional and default to `None`**, so existing behavior is unchanged.

### Example

```python
from basketball_reference_web_scraper import client

client.players_season_totals(
    season_end_year=2018,
    headers={"User-Agent": "my-app/1.0 (contact@example.com)"},
)
```

### Tests

Added `tests/integration/client/test_custom_http_settings.py`:
- a caller-supplied `User-Agent` is applied to the outgoing request
- an arbitrary custom header is applied
- the default `python-requests` User-Agent is still used when no settings are provided (backward-compat)
- `headers` / `proxies` / `timeout` are forwarded to `requests`, and default to `None`

`poetry run coverage run --source=basketball_reference_web_scraper --module pytest --ignore="tests/end to end/"` → **512 passed**.

Happy to adjust the public API shape (e.g. bundling these into a single `http_options` object) if you'd prefer a different design.

Refs #157
