### PR TITLE
Use a raw string for the search result regex

### DIFF
--- a/basketball_reference_web_scraper/parser_service.py
+++ b/basketball_reference_web_scraper/parser_service.py
@@ -15,7 +15,7 @@ from basketball_reference_web_scraper.team_season.parsers import RosterParser, P
 class ParserService:
     PLAY_BY_PLAY_TIMESTAMP_FORMAT = "%M:%S.%f"
     PLAY_BY_PLAY_SCORES_REGEX = "(?P<away_team_score>[0-9]+)-(?P<home_team_score>[0-9]+)"
-    SEARCH_RESULT_RESOURCE_LOCATION_REGEX = '(https?:\/\/www\.basketball-reference\.com\/)?(?P<resource_type>.+?(?=\/)).*\/(?P<resource_identifier>.+).html'
+    SEARCH_RESULT_RESOURCE_LOCATION_REGEX = r'(https?:\/\/www\.basketball-reference\.com\/)?(?P<resource_type>.+?(?=\/)).*\/(?P<resource_identifier>.+).html'
 
     def __init__(self):
         self.team_abbreviation_parser = TeamAbbreviationParser()


### PR DESCRIPTION
Python emits a SyntaxWarning for the `\/` and `\.` sequences in
`ParserService.SEARCH_RESULT_RESOURCE_LOCATION_REGEX`:

    parser_service.py:18: SyntaxWarning: "\/" is an invalid escape sequence.
    Such sequences will not work in the future. Did you mean "\\/"? A raw
    string is also an option.

These have been warnings since Python 3.12 and are slated to become SyntaxErrors,
so this will eventually break on a supported interpreter — `pyproject.toml` lists
3.14 and CI tests it.

Adding an `r` prefix silences it with no behaviour change. Because neither `\/` nor
`\.` is a recognised escape sequence, Python already leaves them intact, so the raw
string is byte-identical to the current value and the compiled regex is unchanged.

Verified on Python 3.14.6: `pytest --ignore="tests/end to end/"` reports 539 passed,
and the warnings summary is now empty (it previously reported 1 warning).